### PR TITLE
Support retries when an API call is rejected

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -55,6 +55,7 @@ If you run E2E test, Set below environment variables.
 
 func initE2ETest() {
 	clientMock = nil
+	RetryCount = 20
 
 	name := os.Getenv("PIXELA4GO_USER_NAME")
 	token := os.Getenv("PIXELA4GO_USER_FIRST_TOKEN")

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,80 @@
+package pixela
+
+import (
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const maxRetryCount = 20
+
+// RetryCount number of retries when an API call is rejected (max: 20)
+var RetryCount = 0
+
+// ErrAPICallRejected API call rejected.
+// See: https://help.pixe.la/en/blog/release-request-rejecting
+var ErrAPICallRejected = errors.New("api call rejected")
+
+type retryer struct {
+	processFunc func(r *retryer)
+	maxRetry    int
+	statusCode  int
+	body        []byte
+	err         error
+}
+
+func (m *retryer) do() error {
+	for i := 0; i <= m.maxRetry; i++ {
+		m.process()
+		if !m.shouldRetry() {
+			return m.err
+		}
+
+		waitTime := m.getWaitTimeExp(i, 100)
+		time.Sleep(time.Millisecond * time.Duration(waitTime))
+	}
+
+	return ErrAPICallRejected
+}
+
+func (m *retryer) process() {
+	m.processFunc(m)
+}
+
+func (m *retryer) shouldRetry() bool {
+	if m.err != nil {
+		return false
+	}
+	if m.statusCode != http.StatusServiceUnavailable {
+		return false
+	}
+
+	r, err := parseNormalResponse(m.body)
+	if err != nil {
+		m.err = errors.Wrapf(err, "failed to parse normal response")
+		return false
+	}
+
+	return strings.HasPrefix(r.Message, "Please retry this request")
+}
+
+func (m *retryer) getWaitTimeExp(retryCount int, baseDelayMilliSeconds int) (delayMilliSeconds int) {
+	if retryCount == 0 {
+		return 0
+	}
+
+	return int(math.Pow(2, float64(retryCount)) * float64(baseDelayMilliSeconds))
+}
+
+func getRetryCount() int {
+	if RetryCount < 0 {
+		return 0
+	}
+	if RetryCount > maxRetryCount {
+		return maxRetryCount
+	}
+	return RetryCount
+}


### PR DESCRIPTION
Support retries when an API call is rejected.

**Note that this function is experimental. The behavior may change or remove**.

This PR is the implementation of the #5.

- Automatically retry API calls when the API returns an HTTP 503 (`{"message":"Please retry this request〜`).
- Other than HTTP 503 (`{"message":"Please retry this request〜`), for example, network errors are not automatically retried.
- Pixela4go users can turn this feature on and off.

## usage

If `pixela.RetryCount > 0` , pixela4go will retry the API call if it is rejected.

```go
pixela.RetryCount = 5 // Retry up to 5 times.
client := pixela.New("YOUR_NAME", "YOUR_TOKEN")

uci := &pixela.UserCreateInput{
	AgreeTermsOfService: pixela.Bool(true),
	NotMinor:            pixela.Bool(true),
	ThanksCode:          pixela.String("thanks-code"),
}
result, err := client.User().CreateWithContext(context.Background(), uci)
if err != nil {
	if err == pixela.ErrAPICallRejected {
		// Retried but was not successful.
	} else {
		// Other error
	}
}
```
