### PR TITLE
Determine by `isRejected` field whether the API call is rejected

### DIFF
--- a/api.go
+++ b/api.go
@@ -32,6 +32,7 @@ type requestParameter struct {
 type Result struct {
 	Message    string `json:"message"`
 	IsSuccess  bool   `json:"isSuccess"`
+	IsRejected bool   `json:"IsRejected"`
 	StatusCode int    `json:"statusCode"`
 }
 

--- a/retry.go
+++ b/retry.go
@@ -3,7 +3,6 @@ package pixela
 import (
 	"math"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -58,7 +57,7 @@ func (m *retryer) shouldRetry() bool {
 		return false
 	}
 
-	return strings.HasPrefix(r.Message, "Please retry this request")
+	return r.IsRejected
 }
 
 func (m *retryer) getWaitTimeExp(retryCount int, baseDelayMilliSeconds int) (delayMilliSeconds int) {


### PR DESCRIPTION
Determine by `isRejected` field whether the API call is rejected.

This PR is an implementation of the following advice.
https://github.com/ebc-2in2crc/pixela4go/pull/6#discussion_r936026349

