### PR TITLE
Add Pixel.Add() and Pixel.Subtract() for specific date

### DIFF
--- a/e2e_pixel_test.go
+++ b/e2e_pixel_test.go
@@ -75,6 +75,24 @@ func testE2EPixelAdd(t *testing.T) {
 	}
 }
 
+func testE2EPixelSubtract(t *testing.T) {
+	input := &PixelSubtractInput{
+		GraphID:  String(graphID),
+		Date:     String(pixelDate),
+		Quantity: String("5"),
+	}
+	result, err := e2eClient.Pixel().Subtract(input)
+	if err != nil {
+		t.Errorf("Pixel.Subtract() got: %+v\nwant: nil", err)
+	}
+	if result.IsSuccess == false {
+		t.Errorf("Pixel.Subtract() got: %+v\nwant: true", result)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("Pixel.Subtract() got: %+v\nwant: %d", result, http.StatusOK)
+	}
+}
+
 func testE2EPixelUpdate(t *testing.T) {
 	input := &PixelUpdateInput{
 		Date:     String(pixelDate),

--- a/e2e_pixel_test.go
+++ b/e2e_pixel_test.go
@@ -57,6 +57,24 @@ func testE2EPixelDecrement(t *testing.T) {
 	}
 }
 
+func testE2EPixelAdd(t *testing.T) {
+	input := &PixelAddInput{
+		GraphID:  String(graphID),
+		Date:     String(pixelDate),
+		Quantity: String("5"),
+	}
+	result, err := e2eClient.Pixel().Add(input)
+	if err != nil {
+		t.Errorf("Pixel.Add() got: %+v\nwant: nil", err)
+	}
+	if result.IsSuccess == false {
+		t.Errorf("Pixel.Add() got: %+v\nwant: true", result)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("Pixel.Add() got: %+v\nwant: %d", result, http.StatusOK)
+	}
+}
+
 func testE2EPixelUpdate(t *testing.T) {
 	input := &PixelUpdateInput{
 		Date:     String(pixelDate),

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -44,6 +44,7 @@ If you run E2E test, Set below environment variables.
 	testE2EPixelIncrement(t)
 	testE2EPixelDecrement(t)
 	testE2EPixelAdd(t)
+	testE2EPixelSubtract(t)
 	testE2EPixelUpdate(t)
 	testE2EPixelGet(t)
 	testE2EPixelDelete(t)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -43,6 +43,7 @@ If you run E2E test, Set below environment variables.
 	testE2EPixelCreate(t)
 	testE2EPixelIncrement(t)
 	testE2EPixelDecrement(t)
+	testE2EPixelAdd(t)
 	testE2EPixelUpdate(t)
 	testE2EPixelGet(t)
 	testE2EPixelDelete(t)

--- a/pixel.go
+++ b/pixel.go
@@ -216,6 +216,47 @@ func (p *Pixel) createUpdateRequestParameter(input *PixelUpdateInput) (*requestP
 	}, nil
 }
 
+// Add adds the specified quantity to the "Pixel" of the specified date.
+func (p *Pixel) Add(input *PixelAddInput) (*Result, error) {
+	return p.AddWithContext(context.Background(), input)
+}
+
+// AddWithContext adds the specified quantity to the "Pixel" of the specified date.
+func (p *Pixel) AddWithContext(ctx context.Context, input *PixelAddInput) (*Result, error) {
+	param, err := p.createAddRequestParameter(input)
+	if err != nil {
+		return &Result{}, errors.Wrapf(err, "failed to create pixel add parameter")
+	}
+
+	return doRequestAndParseResponse(ctx, param)
+}
+
+// PixelAddInput is input of Pixel.Add().
+type PixelAddInput struct {
+	// GraphID is a required field
+	GraphID *string `json:"-"`
+	// Date is a required field
+	Date *string `json:"-"`
+	// Quantity is a required field
+	Quantity *string `json:"quantity"`
+}
+
+func (p *Pixel) createAddRequestParameter(input *PixelAddInput) (*requestParameter, error) {
+	b, err := json.Marshal(input)
+	if err != nil {
+		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+	}
+
+	graphID := StringValue(input.GraphID)
+	date := StringValue(input.Date)
+	return &requestParameter{
+		Method: http.MethodPut,
+		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/%s/add", p.UserName, graphID, date),
+		Header: map[string]string{userToken: p.Token},
+		Body:   b,
+	}, nil
+}
+
 // Delete deletes the registered "Pixel".
 func (p *Pixel) Delete(input *PixelDeleteInput) (*Result, error) {
 	return p.DeleteWithContext(context.Background(), input)

--- a/pixel.go
+++ b/pixel.go
@@ -257,6 +257,47 @@ func (p *Pixel) createAddRequestParameter(input *PixelAddInput) (*requestParamet
 	}, nil
 }
 
+// Subtract subtracts the specified quantity from the "Pixel" of the specified date.
+func (p *Pixel) Subtract(input *PixelSubtractInput) (*Result, error) {
+	return p.SubtractWithContext(context.Background(), input)
+}
+
+// SubtractWithContext subtracts the specified quantity from the "Pixel" of the specified date.
+func (p *Pixel) SubtractWithContext(ctx context.Context, input *PixelSubtractInput) (*Result, error) {
+	param, err := p.createSubtractRequestParameter(input)
+	if err != nil {
+		return &Result{}, errors.Wrapf(err, "failed to create pixel subtract parameter")
+	}
+
+	return doRequestAndParseResponse(ctx, param)
+}
+
+// PixelSubtractInput is input of Pixel.Subtract().
+type PixelSubtractInput struct {
+	// GraphID is a required field
+	GraphID *string `json:"-"`
+	// Date is a required field
+	Date *string `json:"-"`
+	// Quantity is a required field
+	Quantity *string `json:"quantity"`
+}
+
+func (p *Pixel) createSubtractRequestParameter(input *PixelSubtractInput) (*requestParameter, error) {
+	b, err := json.Marshal(input)
+	if err != nil {
+		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+	}
+
+	graphID := StringValue(input.GraphID)
+	date := StringValue(input.Date)
+	return &requestParameter{
+		Method: http.MethodPut,
+		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/%s/subtract", p.UserName, graphID, date),
+		Header: map[string]string{userToken: p.Token},
+		Body:   b,
+	}, nil
+}
+
 // Delete deletes the registered "Pixel".
 func (p *Pixel) Delete(input *PixelDeleteInput) (*Result, error) {
 	return p.DeleteWithContext(context.Background(), input)

--- a/pixel_test.go
+++ b/pixel_test.go
@@ -389,6 +389,68 @@ func TestPixel_AddError(t *testing.T) {
 	testPageNotFoundError(t, err)
 }
 
+func TestPixel_CreateSubtractRequestParameter(t *testing.T) {
+	client := New(userName, token)
+	input := &PixelSubtractInput{
+		GraphID:  String(graphID),
+		Date:     String("20180915"),
+		Quantity: String("3"),
+	}
+	param, err := client.Pixel().createSubtractRequestParameter(input)
+	if err != nil {
+		t.Errorf("got: %v\nwant: nil", err)
+	}
+
+	if param.Method != http.MethodPut {
+		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPut)
+	}
+
+	expect := fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/20180915/subtract", userName, graphID)
+	if param.URL != expect {
+		t.Errorf("URL: %s\nwant: %s", param.URL, expect)
+	}
+
+	if param.Header[userToken] != token {
+		t.Errorf("%s: %s\nwant: %s", userToken, param.Header[userToken], token)
+	}
+
+	s := `{"quantity":"3"}`
+	b := []byte(s)
+	if bytes.Equal(param.Body, b) == false {
+		t.Errorf("Body: %s\nwant: %s", string(param.Body), s)
+	}
+}
+
+func TestPixel_Subtract(t *testing.T) {
+	clientMock = newOKMock()
+
+	client := New(userName, token)
+	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
+	result, err := client.Pixel().Subtract(input)
+
+	testSuccess(t, result, err)
+}
+
+func TestPixel_SubtractFail(t *testing.T) {
+	clientMock = newAPIFailedMock()
+
+	client := New(userName, token)
+	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
+	result, err := client.Pixel().Subtract(input)
+
+	testAPIFailedResult(t, result, err)
+}
+
+func TestPixel_SubtractError(t *testing.T) {
+	clientMock = newPageNotFoundMock()
+
+	client := New(userName, token)
+	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
+	_, err := client.Pixel().Subtract(input)
+
+	testPageNotFoundError(t, err)
+}
+
 func TestPixel_CreateDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}

--- a/pixel_test.go
+++ b/pixel_test.go
@@ -327,6 +327,68 @@ func TestPixel_UpdateError(t *testing.T) {
 	testPageNotFoundError(t, err)
 }
 
+func TestPixel_CreateAddRequestParameter(t *testing.T) {
+	client := New(userName, token)
+	input := &PixelAddInput{
+		GraphID:  String(graphID),
+		Date:     String("20180915"),
+		Quantity: String("5"),
+	}
+	param, err := client.Pixel().createAddRequestParameter(input)
+	if err != nil {
+		t.Errorf("got: %v\nwant: nil", err)
+	}
+
+	if param.Method != http.MethodPut {
+		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPut)
+	}
+
+	expect := fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/20180915/add", userName, graphID)
+	if param.URL != expect {
+		t.Errorf("URL: %s\nwant: %s", param.URL, expect)
+	}
+
+	if param.Header[userToken] != token {
+		t.Errorf("%s: %s\nwant: %s", userToken, param.Header[userToken], token)
+	}
+
+	s := `{"quantity":"5"}`
+	b := []byte(s)
+	if bytes.Equal(param.Body, b) == false {
+		t.Errorf("Body: %s\nwant: %s", string(param.Body), s)
+	}
+}
+
+func TestPixel_Add(t *testing.T) {
+	clientMock = newOKMock()
+
+	client := New(userName, token)
+	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
+	result, err := client.Pixel().Add(input)
+
+	testSuccess(t, result, err)
+}
+
+func TestPixel_AddFail(t *testing.T) {
+	clientMock = newAPIFailedMock()
+
+	client := New(userName, token)
+	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
+	result, err := client.Pixel().Add(input)
+
+	testAPIFailedResult(t, result, err)
+}
+
+func TestPixel_AddError(t *testing.T) {
+	clientMock = newPageNotFoundMock()
+
+	client := New(userName, token)
+	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
+	_, err := client.Pixel().Add(input)
+
+	testPageNotFoundError(t, err)
+}
+
 func TestPixel_CreateDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}


### PR DESCRIPTION
## Summary

- Implements support for Pixela v1.33.0 API endpoints
  - `PUT /v1/users/<username>/graphs/<graphID>/<yyyyMMdd>/add`
  - `PUT /v1/users/<username>/graphs/<graphID>/<yyyyMMdd>/subtract`
- Adds `Pixel.Add()` / `Pixel.AddWithContext()` with `PixelAddInput`
- Adds `Pixel.Subtract()` / `Pixel.SubtractWithContext()` with `PixelSubtractInput`

Closes #37

## Test plan

- [x] Unit tests: parameter verification, success, fail, error (4 tests per method)
- [x] E2E: `testE2EPixelAdd` / `testE2EPixelSubtract` wired into `TestE2E`
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)