### PR TITLE
Add description field to GraphCreateInput and GraphUpdateInput

### DIFF
--- a/e2e_graph_test.go
+++ b/e2e_graph_test.go
@@ -15,6 +15,7 @@ func testE2EGraphCreate(t *testing.T) {
 		Type:           String(GraphTypeInt),
 		Color:          String(GraphColorShibafu),
 		TimeZone:       String("Asia/Tokyo"),
+		Description:    String("graph description"),
 		SelfSufficient: String(GraphSelfSufficientIncrement),
 		StartOnMonday:  Bool(true),
 	}
@@ -34,6 +35,7 @@ func testE2EGraphUpdate(t *testing.T) {
 	input := &GraphUpdateInput{
 		ID:            String(graphID),
 		Unit:          String("times"), // fix typo: "time" => "times"
+		Description:   String("updated graph description"),
 		StartOnMonday: Bool(true),
 	}
 	result, err := e2eClient.Graph().Update(input)

--- a/graph.go
+++ b/graph.go
@@ -44,6 +44,7 @@ type GraphCreateInput struct {
 	// Color is a required field
 	Color               *string `json:"color"`
 	TimeZone            *string `json:"timezone,omitempty"`
+	Description         *string `json:"description,omitempty"`
 	SelfSufficient      *string `json:"selfSufficient,omitempty"`
 	IsSecret            *bool   `json:"isSecret,omitempty"`
 	PublishOptionalData *bool   `json:"publishOptionalData,omitempty"`
@@ -509,6 +510,7 @@ type GraphUpdateInput struct {
 	Unit                *string  `json:"unit,omitempty"`
 	Color               *string  `json:"color,omitempty"`
 	TimeZone            *string  `json:"timezone,omitempty"`
+	Description         *string  `json:"description,omitempty"`
 	PurgeCacheURLs      []string `json:"purgeCacheURLs,omitempty"`
 	SelfSufficient      *string  `json:"selfSufficient,omitempty"`
 	IsSecret            *bool    `json:"isSecret,omitempty"`

--- a/graph_test.go
+++ b/graph_test.go
@@ -18,6 +18,7 @@ func TestGraph_CreateCreateRequestParameter(t *testing.T) {
 		Type:                String(GraphTypeInt),
 		Color:               String(GraphColorShibafu),
 		TimeZone:            String("UTC"),
+		Description:         String("description"),
 		SelfSufficient:      String(GraphSelfSufficientIncrement),
 		IsSecret:            Bool(true),
 		PublishOptionalData: Bool(true),
@@ -40,7 +41,7 @@ func TestGraph_CreateCreateRequestParameter(t *testing.T) {
 		t.Errorf("%s: %s\nwant: %s", userToken, param.Header[userToken], token)
 	}
 
-	s := `{"id":"graph-id","name":"name","unit":"times","type":"int","color":"shibafu","timezone":"UTC","selfSufficient":"increment","isSecret":true,"publishOptionalData":true}`
+	s := `{"id":"graph-id","name":"name","unit":"times","type":"int","color":"shibafu","timezone":"UTC","description":"description","selfSufficient":"increment","isSecret":true,"publishOptionalData":true}`
 	b := []byte(s)
 	if bytes.Equal(param.Body, b) == false {
 		t.Errorf("Body: %s\nwant: %s", string(param.Body), s)
@@ -648,6 +649,7 @@ func TestGraph_CreateUpdateRequestParameter(t *testing.T) {
 		Unit:                String("times"),
 		Color:               String(GraphColorShibafu),
 		TimeZone:            String("UTC"),
+		Description:         String("description"),
 		PurgeCacheURLs:      []string{"https://camo.githubusercontent.com/xxx/xxxx"},
 		SelfSufficient:      String(GraphSelfSufficientIncrement),
 		IsSecret:            Bool(true),
@@ -672,7 +674,7 @@ func TestGraph_CreateUpdateRequestParameter(t *testing.T) {
 		t.Errorf("%s: %s\nwant: %s", userToken, param.Header[userToken], token)
 	}
 
-	s := `{"name":"name","unit":"times","color":"shibafu","timezone":"UTC","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx"],"selfSufficient":"increment","isSecret":true,"publishOptionalData":true}`
+	s := `{"name":"name","unit":"times","color":"shibafu","timezone":"UTC","description":"description","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx"],"selfSufficient":"increment","isSecret":true,"publishOptionalData":true}`
 	b := []byte(s)
 	if bytes.Equal(param.Body, b) == false {
 		t.Errorf("Body: %s\nwant: %s", string(param.Body), s)


### PR DESCRIPTION
## Summary

- Implements support for Pixela v1.34.0
- Adds optional `Description` field to `GraphCreateInput` and `GraphUpdateInput`
  - Serialized as `"description"` in the JSON request body
  - Omitted when nil (`omitempty`)
  - Maximum 256 characters (Pixela API constraint)

Closes #38

## Test plan

- [x] `TestGraph_CreateCreateRequestParameter` — verifies `description` appears in request body
- [x] `TestGraph_CreateUpdateRequestParameter` — verifies `description` appears in request body
- [x] E2E: `testE2EGraphCreate` / `testE2EGraphUpdate` updated to include `Description`
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)