### PR TITLE
Replace deprecated ioutil with io package

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -86,7 +86,7 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 		}
 		defer resp.Body.Close()
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			m.err = errors.Wrapf(err, "failed to read response body")
 			return
@@ -114,7 +114,7 @@ func mustDoRequest(ctx context.Context, param *requestParameter) ([]byte, error)
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return []byte{}, errors.Wrapf(err, "failed to read response body")
 	}

--- a/test_common.go
+++ b/test_common.go
@@ -2,7 +2,7 @@ package pixela
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,7 +22,7 @@ type httpClientMock struct {
 func (c *httpClientMock) do(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{}
 	resp.StatusCode = c.statusCode
-	resp.Body = ioutil.NopCloser(bytes.NewReader(c.body))
+	resp.Body = io.NopCloser(bytes.NewReader(c.body))
 	return resp, nil
 }
 


### PR DESCRIPTION
## Summary

- `ioutil.ReadAll` → `io.ReadAll` (`api.go`)
- `ioutil.NopCloser` → `io.NopCloser` (`test_common.go`)

`io/ioutil` は Go 1.16 で deprecated になったため、`io` パッケージの関数に置き換えます。

## Test plan

- [x] `make test` passes