### PR TITLE
Replace internal serialization types with anonymous structs

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -643,16 +643,6 @@ type PixelWithBody struct {
 	OptionalData string `json:"optionalData"`
 }
 
-type pixelsWithBody struct {
-	Pixels []PixelWithBody `json:"pixels"`
-	Result
-}
-
-type pixelsWithNoBody struct {
-	Pixels []string `json:"pixels"`
-	Result
-}
-
 func unmarshalPixels(b []byte, withBody bool) (*Pixels, error) {
 	if withBody {
 		return unmarshalPixelsWithBody(b)
@@ -661,7 +651,10 @@ func unmarshalPixels(b []byte, withBody bool) (*Pixels, error) {
 }
 
 func unmarshalPixelsWithBody(b []byte) (*Pixels, error) {
-	var pixels pixelsWithBody
+	var pixels struct {
+		Pixels []PixelWithBody `json:"pixels"`
+		Result
+	}
 	if err := json.Unmarshal(b, &pixels); err != nil {
 		return &Pixels{}, errors.Wrapf(err, "failed to unmarshal json")
 	}
@@ -673,7 +666,10 @@ func unmarshalPixelsWithBody(b []byte) (*Pixels, error) {
 }
 
 func unmarshalPixelsNoBody(b []byte) (*Pixels, error) {
-	var pixels pixelsWithNoBody
+	var pixels struct {
+		Pixels []string `json:"pixels"`
+		Result
+	}
 	if err := json.Unmarshal(b, &pixels); err != nil {
 		return &Pixels{}, errors.Wrapf(err, "failed to unmarshal json")
 	}

--- a/user.go
+++ b/user.go
@@ -40,14 +40,19 @@ type UserCreateInput struct {
 }
 
 func (u *User) createCreateRequestParameter(input *UserCreateInput) (*requestParameter, error) {
-	create := &userCreate{
+	b, err := json.Marshal(struct {
+		Token               string `json:"token"`
+		UserName            string `json:"username"`
+		AgreeTermsOfService string `json:"AgreeTermsOfService"`
+		NotMinor            string `json:"NotMinor"`
+		ThanksCode          string `json:"thanksCode,omitempty"`
+	}{
 		Token:               u.Token,
 		UserName:            u.UserName,
 		AgreeTermsOfService: boolToString(BoolValue(input.AgreeTermsOfService)),
 		NotMinor:            boolToString(BoolValue(input.NotMinor)),
 		ThanksCode:          StringValue(input.ThanksCode),
-	}
-	b, err := json.Marshal(create)
+	})
 	if err != nil {
 		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
 	}
@@ -58,14 +63,6 @@ func (u *User) createCreateRequestParameter(input *UserCreateInput) (*requestPar
 		Header: map[string]string{},
 		Body:   b,
 	}, nil
-}
-
-type userCreate struct {
-	Token               string `json:"token"`
-	UserName            string `json:"username"`
-	AgreeTermsOfService string `json:"AgreeTermsOfService"`
-	NotMinor            string `json:"NotMinor"`
-	ThanksCode          string `json:"thanksCode,omitempty"`
 }
 
 func boolToString(b bool) string {
@@ -99,12 +96,15 @@ type UserUpdateInput struct {
 }
 
 func (u *User) createUpdateRequestParameter(input *UserUpdateInput) (*requestParameter, error) {
-	update := userUpdate{
+	b, err := json.Marshal(struct {
+		NewToken          string `json:"newToken"`
+		ThanksCode        string `json:"thanksCode,omitempty"`
+		AllowAIProcessing *bool  `json:"allowAIProcessing,omitempty"`
+	}{
 		NewToken:          StringValue(input.NewToken),
 		ThanksCode:        StringValue(input.ThanksCode),
 		AllowAIProcessing: input.AllowAIProcessing,
-	}
-	b, err := json.Marshal(update)
+	})
 	if err != nil {
 		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
 	}
@@ -115,12 +115,6 @@ func (u *User) createUpdateRequestParameter(input *UserUpdateInput) (*requestPar
 		Header: map[string]string{userToken: u.Token},
 		Body:   b,
 	}, nil
-}
-
-type userUpdate struct {
-	NewToken          string `json:"newToken"`
-	ThanksCode        string `json:"thanksCode,omitempty"`
-	AllowAIProcessing *bool  `json:"allowAIProcessing,omitempty"`
 }
 
 // Delete deletes the specified registered user.


### PR DESCRIPTION
## Summary

- `userCreate`、`userUpdate`（`user.go`）を廃止し、`createXxxRequestParameter` 内の無名構造体に置き換え
- `pixelsWithBody`、`pixelsWithNoBody`（`graph.go`）を廃止し、`unmarshalPixelsXxx` 内の無名構造体に置き換え

これらの内部型は JSON のシリアライズ/デシリアライズのためだけに存在しており、対応する Input 型との重複が生じていました。無名構造体に置き換えることで、ファイルスコープの名前付き型を減らしつつ同等の機能を維持します。

## Test plan

- [x] `make test` passes