### PR TITLE
Remove error return from createXxx functions that never fail

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -100,12 +100,7 @@ func (g *Graph) GetAll() (*GraphDefinitions, error) {
 
 // GetAllWithContext gets all predefined pixelation graph definitions.
 func (g *Graph) GetAllWithContext(ctx context.Context) (*GraphDefinitions, error) {
-	param, err := g.createGetAllRequestParameter()
-	if err != nil {
-		return &GraphDefinitions{}, errors.Wrapf(err, "failed to create get all graph parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createGetAllRequestParameter())
 	if err != nil {
 		return &GraphDefinitions{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -120,13 +115,13 @@ func (g *Graph) GetAllWithContext(ctx context.Context) (*GraphDefinitions, error
 	return &definitions, nil
 }
 
-func (g *Graph) createGetAllRequestParameter() (*requestParameter, error) {
+func (g *Graph) createGetAllRequestParameter() *requestParameter {
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs", g.UserName),
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // GraphDefinitions is graph definition list.
@@ -157,12 +152,7 @@ func (g *Graph) GetLatestPixel(input *GraphGetLatestPixelInput) (*GraphPixel, er
 
 // GetLatestPixelWithContext gets the latest Pixel registered in the graph.
 func (g *Graph) GetLatestPixelWithContext(ctx context.Context, input *GraphGetLatestPixelInput) (*GraphPixel, error) {
-	param, err := g.createGetLatestPixelRequestParameter(input)
-	if err != nil {
-		return &GraphPixel{}, errors.Wrapf(err, "failed to create get latest pixel parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createGetLatestPixelRequestParameter(input))
 	if err != nil {
 		return &GraphPixel{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -177,14 +167,14 @@ func (g *Graph) GetLatestPixelWithContext(ctx context.Context, input *GraphGetLa
 	return &pixel, nil
 }
 
-func (g *Graph) createGetLatestPixelRequestParameter(input *GraphGetLatestPixelInput) (*requestParameter, error) {
+func (g *Graph) createGetLatestPixelRequestParameter(input *GraphGetLatestPixelInput) *requestParameter {
 	ID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/latest", g.UserName, ID),
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // GraphGetLatestPixelInput is input of Graph.GetLatestPixel().
@@ -208,12 +198,7 @@ func (g *Graph) GetToday(input *GraphGetTodayInput) (*GraphPixel, error) {
 
 // GetTodayWithContext gets the Pixel registered on the day of the request.
 func (g *Graph) GetTodayWithContext(ctx context.Context, input *GraphGetTodayInput) (*GraphPixel, error) {
-	param, err := g.createGetTodayRequestParameter(input)
-	if err != nil {
-		return &GraphPixel{}, errors.Wrapf(err, "failed to create get today pixel parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createGetTodayRequestParameter(input))
 	if err != nil {
 		return &GraphPixel{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -228,7 +213,7 @@ func (g *Graph) GetTodayWithContext(ctx context.Context, input *GraphGetTodayInp
 	return &pixel, nil
 }
 
-func (g *Graph) createGetTodayRequestParameter(input *GraphGetTodayInput) (*requestParameter, error) {
+func (g *Graph) createGetTodayRequestParameter(input *GraphGetTodayInput) *requestParameter {
 	ID := StringValue(input.ID)
 
 	// Create base URL without query parameters
@@ -252,7 +237,7 @@ func (g *Graph) createGetTodayRequestParameter(input *GraphGetTodayInput) (*requ
 		URL:    baseURL,
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // GraphGetTodayInput is input of Graph.GetToday().
@@ -272,12 +257,7 @@ func (g *Graph) GetSVG(input *GraphGetSVGInput) (string, error) {
 
 // GetSVGWithContext get a graph expressed in SVG format diagram that based on the registered information.
 func (g *Graph) GetSVGWithContext(ctx context.Context, input *GraphGetSVGInput) (string, error) {
-	param, err := g.createGetSVGRequestParameter(input)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to create get svg parameter")
-	}
-
-	b, err := mustDoRequest(ctx, param)
+	b, err := mustDoRequest(ctx, g.createGetSVGRequestParameter(input))
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to do request")
 	}
@@ -296,7 +276,7 @@ type GraphGetSVGInput struct {
 	GreaterThan *string `json:"greaterThan,omitempty"`
 }
 
-func (g *Graph) createGetSVGRequestParameter(input *GraphGetSVGInput) (*requestParameter, error) {
+func (g *Graph) createGetSVGRequestParameter(input *GraphGetSVGInput) *requestParameter {
 	ID := StringValue(input.ID)
 
 	// Create base URL without query parameters
@@ -341,7 +321,7 @@ func (g *Graph) createGetSVGRequestParameter(input *GraphGetSVGInput) (*requestP
 		URL:    baseURL,
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Specify the graph display mode.
@@ -449,12 +429,7 @@ func (g *Graph) Stats(input *GraphStatsInput) (*Stats, error) {
 
 // StatsWithContext gets various statistics based on the registered information.
 func (g *Graph) StatsWithContext(ctx context.Context, input *GraphStatsInput) (*Stats, error) {
-	param, err := g.createStatsRequestParameter(input)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create graph stats request parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createStatsRequestParameter(input))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to do request")
 	}
@@ -475,14 +450,14 @@ type GraphStatsInput struct {
 	ID *string
 }
 
-func (g *Graph) createStatsRequestParameter(input *GraphStatsInput) (*requestParameter, error) {
+func (g *Graph) createStatsRequestParameter(input *GraphStatsInput) *requestParameter {
 	ID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/stats", g.UserName, ID),
 		Header: map[string]string{},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Update updates predefined pixelation graph definitions.
@@ -540,12 +515,7 @@ func (g *Graph) Delete(input *GraphDeleteInput) (*Result, error) {
 
 // DeleteWithContext deletes the predefined pixelation graph definition.
 func (g *Graph) DeleteWithContext(ctx context.Context, input *GraphDeleteInput) (*Result, error) {
-	param, err := g.createDeleteRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph delete parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.createDeleteRequestParameter(input))
 }
 
 // GraphDeleteInput is input of Graph.Delete().
@@ -554,14 +524,14 @@ type GraphDeleteInput struct {
 	ID *string `json:"-"`
 }
 
-func (g *Graph) createDeleteRequestParameter(input *GraphDeleteInput) (*requestParameter, error) {
+func (g *Graph) createDeleteRequestParameter(input *GraphDeleteInput) *requestParameter {
 	ID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodDelete,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s", g.UserName, ID),
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // GetPixelDates gets a Date list of Pixel registered in the graph specified by graphID.
@@ -599,12 +569,7 @@ func (g *Graph) GetPixelDates(input *GraphGetPixelDatesInput) (*Pixels, error) {
 // You will get a list you specify.
 // You can not specify a period greater than 365 days.
 func (g *Graph) GetPixelDatesWithContext(ctx context.Context, input *GraphGetPixelDatesInput) (*Pixels, error) {
-	param, err := g.createGetPixelDatesRequestParameter(input)
-	if err != nil {
-		return &Pixels{}, errors.Wrapf(err, "failed to create get pixel dates parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createGetPixelDatesRequestParameter(input))
 	if err != nil {
 		return &Pixels{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -680,7 +645,7 @@ func unmarshalPixelsNoBody(b []byte) (*Pixels, error) {
 	}, nil
 }
 
-func (g *Graph) createGetPixelDatesRequestParameter(input *GraphGetPixelDatesInput) (*requestParameter, error) {
+func (g *Graph) createGetPixelDatesRequestParameter(input *GraphGetPixelDatesInput) *requestParameter {
 	ID := StringValue(input.ID)
 	baseURL := fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/pixels", g.UserName, ID)
 
@@ -703,7 +668,7 @@ func (g *Graph) createGetPixelDatesRequestParameter(input *GraphGetPixelDatesInp
 		URL:    baseURL,
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Stopwatch start and end the measurement of the time.
@@ -713,12 +678,7 @@ func (g *Graph) Stopwatch(input *GraphStopwatchInput) (*Result, error) {
 
 // StopwatchWithContext start and end the measurement of the time.
 func (g *Graph) StopwatchWithContext(ctx context.Context, input *GraphStopwatchInput) (*Result, error) {
-	param, err := g.createStopwatchRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph stopwatch parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.createStopwatchRequestParameter(input))
 }
 
 // GraphStopwatchInput is input of Graph.Stopwatch().
@@ -727,14 +687,14 @@ type GraphStopwatchInput struct {
 	ID *string
 }
 
-func (g *Graph) createStopwatchRequestParameter(input *GraphStopwatchInput) (*requestParameter, error) {
+func (g *Graph) createStopwatchRequestParameter(input *GraphStopwatchInput) *requestParameter {
 	graphID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodPost,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/stopwatch", g.UserName, graphID),
 		Header: map[string]string{contentLength: "0", userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Get gets predefined pixelation graph definitions.
@@ -744,12 +704,7 @@ func (g *Graph) Get(input *GraphGetInput) (*GraphDefinition, error) {
 
 // GetWithContext gets predefined pixelation graph definitions.
 func (g *Graph) GetWithContext(ctx context.Context, input *GraphGetInput) (*GraphDefinition, error) {
-	param, err := g.createGetRequestParameter(input)
-	if err != nil {
-		return &GraphDefinition{}, errors.Wrapf(err, "failed to create get graph parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createGetRequestParameter(input))
 	if err != nil {
 		return &GraphDefinition{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -764,14 +719,14 @@ func (g *Graph) GetWithContext(ctx context.Context, input *GraphGetInput) (*Grap
 	return &definition, nil
 }
 
-func (g *Graph) createGetRequestParameter(input *GraphGetInput) (*requestParameter, error) {
+func (g *Graph) createGetRequestParameter(input *GraphGetInput) *requestParameter {
 	ID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/graph-def", g.UserName, ID),
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // GraphGetInput is input of Graph.Get().
@@ -863,12 +818,7 @@ func (g *Graph) Analyze(input *GraphAnalyzeInput) (*GraphAnalysis, error) {
 
 // AnalyzeWithContext analyzes the graph by AI and returns the result.
 func (g *Graph) AnalyzeWithContext(ctx context.Context, input *GraphAnalyzeInput) (*GraphAnalysis, error) {
-	param, err := g.createAnalyzeRequestParameter(input)
-	if err != nil {
-		return &GraphAnalysis{}, errors.Wrapf(err, "failed to create graph analyze parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, g.createAnalyzeRequestParameter(input))
 	if err != nil {
 		return &GraphAnalysis{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -895,12 +845,12 @@ type GraphAnalysis struct {
 	Result
 }
 
-func (g *Graph) createAnalyzeRequestParameter(input *GraphAnalyzeInput) (*requestParameter, error) {
+func (g *Graph) createAnalyzeRequestParameter(input *GraphAnalyzeInput) *requestParameter {
 	ID := StringValue(input.ID)
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/analyze", g.UserName, ID),
 		Header: map[string]string{userToken: g.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }

--- a/graph_test.go
+++ b/graph_test.go
@@ -111,10 +111,7 @@ func TestGraph_CreateError(t *testing.T) {
 
 func TestGraph_CreateGetAllRequestParameter(t *testing.T) {
 	client := New(userName, token)
-	param, err := client.Graph().createGetAllRequestParameter()
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createGetAllRequestParameter()
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -191,10 +188,7 @@ func TestGraph_GetAllError(t *testing.T) {
 func TestGraph_CreateGetLatestPixelRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphGetLatestPixelInput{ID: String(graphID)}
-	param, err := client.Graph().createGetLatestPixelRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createGetLatestPixelRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPost)
@@ -260,10 +254,7 @@ func TestGraph_CreateGetTodayRequestParameter(t *testing.T) {
 	input1 := &GraphGetTodayInput{
 		ID: String(graphID),
 	}
-	param1, err := client.Graph().createGetTodayRequestParameter(input1)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param1 := client.Graph().createGetTodayRequestParameter(input1)
 
 	if param1.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param1.Method, http.MethodGet)
@@ -287,10 +278,7 @@ func TestGraph_CreateGetTodayRequestParameter(t *testing.T) {
 		ID:          String(graphID),
 		ReturnEmpty: Bool(true),
 	}
-	param2, err := client.Graph().createGetTodayRequestParameter(input2)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param2 := client.Graph().createGetTodayRequestParameter(input2)
 
 	// Parse the actual URL to compare parts independently of query parameter order
 	actualURL, err := url.Parse(param2.URL)
@@ -366,10 +354,7 @@ func TestGraph_CreateGetSVGRequestParameter(t *testing.T) {
 		LessThan:    String("10"),
 		GreaterThan: String("5"),
 	}
-	param, err := client.Graph().createGetSVGRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createGetSVGRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -570,10 +555,7 @@ func TestGraph_URL(t *testing.T) {
 func TestGraph_CreateStatsRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphStatsInput{ID: String(graphID)}
-	param, err := client.Graph().createStatsRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createStatsRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -745,10 +727,7 @@ func TestGraph_UpdateError(t *testing.T) {
 func TestGraph_CreateDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphDeleteInput{ID: String(graphID)}
-	param, err := client.Graph().createDeleteRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createDeleteRequestParameter(input)
 
 	if param.Method != http.MethodDelete {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodDelete)
@@ -806,10 +785,7 @@ func TestGraph_CreateGetPixelDatesRequestParameter(t *testing.T) {
 		To:       String("20181231"),
 		WithBody: Bool(true),
 	}
-	param, err := client.Graph().createGetPixelDatesRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createGetPixelDatesRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -908,10 +884,7 @@ func TestGraph_GetPixelDatesError(t *testing.T) {
 func TestGraph_CreateStopwatchRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphStopwatchInput{ID: String(graphID)}
-	param, err := client.Graph().createStopwatchRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createStopwatchRequestParameter(input)
 
 	if param.Method != http.MethodPost {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPost)
@@ -967,10 +940,7 @@ func TestGraph_StopwatchError(t *testing.T) {
 func TestGraph_CreateGetRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphGetInput{ID: String(graphID)}
-	param, err := client.Graph().createGetRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createGetRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -1185,10 +1155,7 @@ func TestGraph_SubtractError(t *testing.T) {
 func TestGraph_CreateAnalyzeRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &GraphAnalyzeInput{ID: String(graphID)}
-	param, err := client.Graph().createAnalyzeRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Graph().createAnalyzeRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)

--- a/pixel.go
+++ b/pixel.go
@@ -65,12 +65,7 @@ func (p *Pixel) Increment(input *PixelIncrementInput) (*Result, error) {
 // IncrementWithContext increments quantity "Pixel" of the day (it is used "timezone" setting if Graph's "timezone" is specified, if not specified, calculates it in "UTC").
 // If the graph type is int then 1 added, and for float then 0.01 added.
 func (p *Pixel) IncrementWithContext(ctx context.Context, input *PixelIncrementInput) (*Result, error) {
-	param, err := p.createIncrementRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel increment parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.createIncrementRequestParameter(input))
 }
 
 // PixelIncrementInput is input of Pixel.Increment().
@@ -79,14 +74,14 @@ type PixelIncrementInput struct {
 	GraphID *string
 }
 
-func (p *Pixel) createIncrementRequestParameter(input *PixelIncrementInput) (*requestParameter, error) {
+func (p *Pixel) createIncrementRequestParameter(input *PixelIncrementInput) *requestParameter {
 	graphID := StringValue(input.GraphID)
 	return &requestParameter{
 		Method: http.MethodPut,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/increment", p.UserName, graphID),
 		Header: map[string]string{contentLength: "0", userToken: p.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Decrement decrements quantity "Pixel" of the day (it is used "timezone" setting if Graph's "timezone" is specified, if not specified, calculates it in "UTC").
@@ -98,12 +93,7 @@ func (p *Pixel) Decrement(input *PixelDecrementInput) (*Result, error) {
 // DecrementWithContext decrements quantity "Pixel" of the day (it is used "timezone" setting if Graph's "timezone" is specified, if not specified, calculates it in "UTC").
 // If the graph type is int then -1 added, and for float then -0.01 added.
 func (p *Pixel) DecrementWithContext(ctx context.Context, input *PixelDecrementInput) (*Result, error) {
-	param, err := p.createDecrementRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel decrement parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.createDecrementRequestParameter(input))
 }
 
 // PixelDecrementInput is input of Pixel.Decrement().
@@ -112,14 +102,14 @@ type PixelDecrementInput struct {
 	GraphID *string
 }
 
-func (p *Pixel) createDecrementRequestParameter(input *PixelDecrementInput) (*requestParameter, error) {
+func (p *Pixel) createDecrementRequestParameter(input *PixelDecrementInput) *requestParameter {
 	graphID := StringValue(input.GraphID)
 	return &requestParameter{
 		Method: http.MethodPut,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/decrement", p.UserName, graphID),
 		Header: map[string]string{contentLength: "0", userToken: p.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Get gets registered quantity as "Pixel".
@@ -129,12 +119,7 @@ func (p *Pixel) Get(input *PixelGetInput) (*Quantity, error) {
 
 // GetWithContext gets registered quantity as "Pixel".
 func (p *Pixel) GetWithContext(ctx context.Context, input *PixelGetInput) (*Quantity, error) {
-	param, err := p.createGetRequestParameter(input)
-	if err != nil {
-		return &Quantity{}, errors.Wrapf(err, "failed to create pixel get parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, p.createGetRequestParameter(input))
 	if err != nil {
 		return &Quantity{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -157,7 +142,7 @@ type PixelGetInput struct {
 	Date *string
 }
 
-func (p *Pixel) createGetRequestParameter(input *PixelGetInput) (*requestParameter, error) {
+func (p *Pixel) createGetRequestParameter(input *PixelGetInput) *requestParameter {
 	graphID := StringValue(input.GraphID)
 	date := StringValue(input.Date)
 	return &requestParameter{
@@ -165,7 +150,7 @@ func (p *Pixel) createGetRequestParameter(input *PixelGetInput) (*requestParamet
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/%s", p.UserName, graphID, date),
 		Header: map[string]string{userToken: p.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Quantity ... registered quantity.
@@ -305,12 +290,7 @@ func (p *Pixel) Delete(input *PixelDeleteInput) (*Result, error) {
 
 // DeleteWithContext deletes the registered "Pixel".
 func (p *Pixel) DeleteWithContext(ctx context.Context, input *PixelDeleteInput) (*Result, error) {
-	param, err := p.createDeleteRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel delete parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.createDeleteRequestParameter(input))
 }
 
 // PixelDeleteInput is input of Pixel.Delete().
@@ -321,7 +301,7 @@ type PixelDeleteInput struct {
 	Date *string
 }
 
-func (p *Pixel) createDeleteRequestParameter(input *PixelDeleteInput) (*requestParameter, error) {
+func (p *Pixel) createDeleteRequestParameter(input *PixelDeleteInput) *requestParameter {
 	graphID := StringValue(input.GraphID)
 	date := StringValue(input.Date)
 	return &requestParameter{
@@ -329,5 +309,5 @@ func (p *Pixel) createDeleteRequestParameter(input *PixelDeleteInput) (*requestP
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/graphs/%s/%s", p.UserName, graphID, date),
 		Header: map[string]string{userToken: p.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }

--- a/pixel_test.go
+++ b/pixel_test.go
@@ -73,10 +73,7 @@ func TestPixel_CreateError(t *testing.T) {
 func TestPixel_CreateIncrementRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelIncrementInput{GraphID: String(graphID)}
-	param, err := client.Pixel().createIncrementRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Pixel().createIncrementRequestParameter(input)
 
 	if param.Method != http.MethodPut {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPut)
@@ -132,10 +129,7 @@ func TestPixel_IncrementError(t *testing.T) {
 func TestPixel_CreateDecrementRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelDecrementInput{GraphID: String(graphID)}
-	param, err := client.Pixel().createDecrementRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Pixel().createDecrementRequestParameter(input)
 
 	if param.Method != http.MethodPut {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPut)
@@ -187,10 +181,7 @@ func TestPixel_DecrementError(t *testing.T) {
 func TestPixel_CreateGetRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelGetInput{GraphID: String(graphID), Date: String("20180915")}
-	param, err := client.Pixel().createGetRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Pixel().createGetRequestParameter(input)
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -454,10 +445,7 @@ func TestPixel_SubtractError(t *testing.T) {
 func TestPixel_CreateDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}
-	param, err := client.Pixel().createDeleteRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Pixel().createDeleteRequestParameter(input)
 
 	if param.Method != http.MethodDelete {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodDelete)

--- a/user.go
+++ b/user.go
@@ -124,19 +124,14 @@ func (u *User) Delete() (*Result, error) {
 
 // DeleteWithContext deletes the specified registered user.
 func (u *User) DeleteWithContext(ctx context.Context) (*Result, error) {
-	param, err := u.createDeleteRequestParameter()
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create user delete parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, u.createDeleteRequestParameter())
 }
 
-func (u *User) createDeleteRequestParameter() (*requestParameter, error) {
+func (u *User) createDeleteRequestParameter() *requestParameter {
 	return &requestParameter{
 		Method: http.MethodDelete,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s", u.UserName),
 		Header: map[string]string{userToken: u.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }

--- a/user_test.go
+++ b/user_test.go
@@ -158,10 +158,7 @@ func TestUserUpdateError(t *testing.T) {
 
 func TestCreateUserDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
-	param, err := client.User().createDeleteRequestParameter()
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.User().createDeleteRequestParameter()
 
 	if param.Method != http.MethodDelete {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodDelete)

--- a/webhook.go
+++ b/webhook.go
@@ -85,12 +85,7 @@ func (w *Webhook) GetAll() (*WebhookDefinitions, error) {
 
 // GetAllWithContext get all predefined webhooks definitions.
 func (w *Webhook) GetAllWithContext(ctx context.Context) (*WebhookDefinitions, error) {
-	param, err := w.createGetAllRequestParameter()
-	if err != nil {
-		return &WebhookDefinitions{}, errors.Wrapf(err, "failed to create get all webhooks parameter")
-	}
-
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, w.createGetAllRequestParameter())
 	if err != nil {
 		return &WebhookDefinitions{}, errors.Wrapf(err, "failed to do request")
 	}
@@ -118,13 +113,13 @@ type WebhookDefinition struct {
 	Type        string `json:"type"`
 }
 
-func (w *Webhook) createGetAllRequestParameter() (*requestParameter, error) {
+func (w *Webhook) createGetAllRequestParameter() *requestParameter {
 	return &requestParameter{
 		Method: http.MethodGet,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/webhooks", w.UserName),
 		Header: map[string]string{userToken: w.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Delete delete the registered Webhook.
@@ -134,12 +129,7 @@ func (w *Webhook) Delete(input *WebhookDeleteInput) (*Result, error) {
 
 // DeleteWithContext delete the registered Webhook.
 func (w *Webhook) DeleteWithContext(ctx context.Context, input *WebhookDeleteInput) (*Result, error) {
-	param, err := w.createDeleteRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create webhook delete parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, w.createDeleteRequestParameter(input))
 }
 
 // WebhookDeleteInput is input of Webhook.Delete().
@@ -148,14 +138,14 @@ type WebhookDeleteInput struct {
 	WebhookHash *string
 }
 
-func (w *Webhook) createDeleteRequestParameter(input *WebhookDeleteInput) (*requestParameter, error) {
+func (w *Webhook) createDeleteRequestParameter(input *WebhookDeleteInput) *requestParameter {
 	hash := StringValue(input.WebhookHash)
 	return &requestParameter{
 		Method: http.MethodDelete,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/webhooks/%s", w.UserName, hash),
 		Header: map[string]string{userToken: w.Token},
 		Body:   []byte{},
-	}, nil
+	}
 }
 
 // Invoke invoke the webhook registered in advance.
@@ -167,23 +157,18 @@ func (w *Webhook) Invoke(input *WebhookInvokeInput) (*Result, error) {
 // InvokeWithContext invoke the webhook registered in advance.
 // It is used "timezone" setting as post date if Graph's "timezone" is specified, if not specified, calculates it in "UTC".
 func (w *Webhook) InvokeWithContext(ctx context.Context, input *WebhookInvokeInput) (*Result, error) {
-	param, err := w.createInvokeRequestParameter(input)
-	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create webhook invoke parameter")
-	}
-
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, w.createInvokeRequestParameter(input))
 }
 
 // WebhookInvokeInput is input of Webhook.Invoke().
 type WebhookInvokeInput WebhookDeleteInput
 
-func (w *Webhook) createInvokeRequestParameter(input *WebhookInvokeInput) (*requestParameter, error) {
+func (w *Webhook) createInvokeRequestParameter(input *WebhookInvokeInput) *requestParameter {
 	hash := StringValue(input.WebhookHash)
 	return &requestParameter{
 		Method: http.MethodPost,
 		URL:    fmt.Sprintf(APIBaseURLForV1+"/users/%s/webhooks/%s", w.UserName, hash),
 		Header: map[string]string{contentLength: "0"},
 		Body:   []byte{},
-	}, nil
+	}
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -91,10 +91,7 @@ func TestWebhook_CreateError(t *testing.T) {
 
 func TestCreateWebhook_GetAllRequestParameter(t *testing.T) {
 	client := New(userName, token)
-	param, err := client.Webhook().createGetAllRequestParameter()
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Webhook().createGetAllRequestParameter()
 
 	if param.Method != http.MethodGet {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodGet)
@@ -161,10 +158,7 @@ func TestWebhook_GetAllError(t *testing.T) {
 func TestWebhook_CreateDeleteRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &WebhookDeleteInput{WebhookHash: String("webhook-hash")}
-	param, err := client.Webhook().createDeleteRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Webhook().createDeleteRequestParameter(input)
 
 	if param.Method != http.MethodDelete {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodDelete)
@@ -217,10 +211,7 @@ func TestWebhook_DeleteError(t *testing.T) {
 func TestWebhook_CreateInvokeRequestParameter(t *testing.T) {
 	client := New(userName, token)
 	input := &WebhookInvokeInput{WebhookHash: String("webhook-hash")}
-	param, err := client.Webhook().createInvokeRequestParameter(input)
-	if err != nil {
-		t.Errorf("got: %v\nwant: nil", err)
-	}
+	param := client.Webhook().createInvokeRequestParameter(input)
 
 	if param.Method != http.MethodPost {
 		t.Errorf("request method: %s\nwant: %s", param.Method, http.MethodPost)


### PR DESCRIPTION
## Summary

`createXxxRequestParameter` 関数を2種類に分類し、片方の error を除去します。

| 種別 | 関数数 | 変更内容 |
|------|:---:|------|
| `json.Marshal` なし（URL 文字列組み立てのみ） | 16 | `*requestParameter` のみ返すよう変更 |
| `json.Marshal` あり | 13 | 変更なし（error を維持） |

`json.Marshal` を呼ばない関数は構造的に失敗しえないため、error return は意味のないハンドリングを呼び出し側に強いていました。これを除去することで `WithContext` メソッドとテストのコードが簡潔になります。

## 変更ファイル

- `user.go` — `createDeleteRequestParameter`
- `pixel.go` — `createIncrementRequestParameter`, `createDecrementRequestParameter`, `createGetRequestParameter`, `createDeleteRequestParameter`
- `graph.go` — `createGetAllRequestParameter`, `createGetLatestPixelRequestParameter`, `createGetTodayRequestParameter`, `createGetSVGRequestParameter`, `createStatsRequestParameter`, `createDeleteRequestParameter`, `createGetPixelDatesRequestParameter`, `createStopwatchRequestParameter`, `createGetRequestParameter`, `createAnalyzeRequestParameter`
- `webhook.go` — `createGetAllRequestParameter`, `createDeleteRequestParameter`, `createInvokeRequestParameter`
- 各 `*_test.go`

## Test plan

- [x] `make test` passes