### PR TITLE
Replace github.com/pkg/errors with standard fmt.Errorf

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 // APIBaseURL is Base URL for API requests.
@@ -43,7 +42,7 @@ func newHTTPRequest(ctx context.Context, param *requestParameter) (*http.Request
 		param.URL,
 		bytes.NewReader(param.Body))
 	if err != nil {
-		return &http.Request{}, errors.Wrap(err, "failed to create http.Request")
+		return &http.Request{}, fmt.Errorf("failed to create http.Request: %w", err)
 	}
 	if param.Header != nil {
 		for k, v := range param.Header {
@@ -71,7 +70,7 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 	return func(m *retryer) {
 		req, err := newHTTPRequest(ctx, param)
 		if err != nil {
-			m.err = errors.Wrap(err, "failed to create http.Request")
+			m.err = fmt.Errorf("failed to create http.Request: %w", err)
 			return
 		}
 
@@ -81,14 +80,14 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 			resp, err = clientMock.do(req)
 		}
 		if err != nil {
-			m.err = errors.Wrapf(err, "failed http.Client do")
+			m.err = fmt.Errorf("failed http.Client do: %w", err)
 			return
 		}
 		defer resp.Body.Close()
 
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
-			m.err = errors.Wrapf(err, "failed to read response body")
+			m.err = fmt.Errorf("failed to read response body: %w", err)
 			return
 		}
 
@@ -101,7 +100,7 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 func mustDoRequest(ctx context.Context, param *requestParameter) ([]byte, error) {
 	req, err := newHTTPRequest(ctx, param)
 	if err != nil {
-		return []byte{}, errors.Wrap(err, "failed to create http.Request")
+		return []byte{}, fmt.Errorf("failed to create http.Request: %w", err)
 	}
 
 	client := http.Client{}
@@ -110,17 +109,17 @@ func mustDoRequest(ctx context.Context, param *requestParameter) ([]byte, error)
 		resp, err = clientMock.do(req)
 	}
 	if err != nil {
-		return []byte{}, errors.Wrapf(err, "failed http.Client do")
+		return []byte{}, fmt.Errorf("failed http.Client do: %w", err)
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return []byte{}, errors.Wrapf(err, "failed to read response body")
+		return []byte{}, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if resp.StatusCode >= 300 {
-		return b, errors.Errorf("failed to call API: %s", string(b))
+		return b, fmt.Errorf("failed to call API: %s", string(b))
 	}
 
 	return b, nil
@@ -137,7 +136,7 @@ func doRequestAndParseResponse(ctx context.Context, param *requestParameter) (*R
 
 	r, err := parseNormalResponse(retry.body)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to parse normal response")
+		return &Result{}, fmt.Errorf("failed to parse normal response: %w", err)
 	}
 
 	r.StatusCode = retry.statusCode
@@ -147,7 +146,7 @@ func doRequestAndParseResponse(ctx context.Context, param *requestParameter) (*R
 func parseNormalResponse(b []byte) (*Result, error) {
 	var result Result
 	if err := json.Unmarshal(b, &result); err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to unmarshal json: %s", string(b))
+		return &Result{}, fmt.Errorf("failed to unmarshal json: %s: %w", string(b), err)
 	}
 	return &result, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/ebc-2in2crc/pixela4go
 
 go 1.24
-
-require github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/graph.go
+++ b/graph.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/pkg/errors"
 )
 
 // A Graph manages communication with the Pixela graph API.
@@ -25,7 +24,7 @@ func (g *Graph) Create(input *GraphCreateInput) (*Result, error) {
 func (g *Graph) CreateWithContext(ctx context.Context, input *GraphCreateInput) (*Result, error) {
 	param, err := g.createCreateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph create parameter")
+		return &Result{}, fmt.Errorf("failed to create graph create parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -54,7 +53,7 @@ type GraphCreateInput struct {
 func (g *Graph) createCreateRequestParameter(input *GraphCreateInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	return &requestParameter{
@@ -102,13 +101,13 @@ func (g *Graph) GetAll() (*GraphDefinitions, error) {
 func (g *Graph) GetAllWithContext(ctx context.Context) (*GraphDefinitions, error) {
 	b, status, err := doRequest(ctx, g.createGetAllRequestParameter())
 	if err != nil {
-		return &GraphDefinitions{}, errors.Wrapf(err, "failed to do request")
+		return &GraphDefinitions{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var definitions GraphDefinitions
 	definitions.StatusCode = status
 	if err := json.Unmarshal(b, &definitions); err != nil {
-		return &GraphDefinitions{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &GraphDefinitions{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	definitions.IsSuccess = definitions.Message == ""
@@ -154,13 +153,13 @@ func (g *Graph) GetLatestPixel(input *GraphGetLatestPixelInput) (*GraphPixel, er
 func (g *Graph) GetLatestPixelWithContext(ctx context.Context, input *GraphGetLatestPixelInput) (*GraphPixel, error) {
 	b, status, err := doRequest(ctx, g.createGetLatestPixelRequestParameter(input))
 	if err != nil {
-		return &GraphPixel{}, errors.Wrapf(err, "failed to do request")
+		return &GraphPixel{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var pixel GraphPixel
 	pixel.StatusCode = status
 	if err := json.Unmarshal(b, &pixel); err != nil {
-		return &pixel, errors.Wrapf(err, "failed to unmarshal json")
+		return &pixel, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	pixel.IsSuccess = pixel.StatusCode == http.StatusOK
@@ -200,13 +199,13 @@ func (g *Graph) GetToday(input *GraphGetTodayInput) (*GraphPixel, error) {
 func (g *Graph) GetTodayWithContext(ctx context.Context, input *GraphGetTodayInput) (*GraphPixel, error) {
 	b, status, err := doRequest(ctx, g.createGetTodayRequestParameter(input))
 	if err != nil {
-		return &GraphPixel{}, errors.Wrapf(err, "failed to do request")
+		return &GraphPixel{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var pixel GraphPixel
 	pixel.StatusCode = status
 	if err := json.Unmarshal(b, &pixel); err != nil {
-		return &pixel, errors.Wrapf(err, "failed to unmarshal json")
+		return &pixel, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	pixel.IsSuccess = pixel.StatusCode == http.StatusOK
@@ -259,7 +258,7 @@ func (g *Graph) GetSVG(input *GraphGetSVGInput) (string, error) {
 func (g *Graph) GetSVGWithContext(ctx context.Context, input *GraphGetSVGInput) (string, error) {
 	b, err := mustDoRequest(ctx, g.createGetSVGRequestParameter(input))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to do request")
+		return "", fmt.Errorf("failed to do request: %w", err)
 	}
 
 	return string(b), nil
@@ -353,7 +352,7 @@ func (g *Graph) UpdatePixels(input *GraphUpdatePixelsInput) (*Result, error) {
 func (g *Graph) UpdatePixelsWithContext(ctx context.Context, input *GraphUpdatePixelsInput) (*Result, error) {
 	param, err := g.createUpdatePixelsRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph update pixels parameter")
+		return &Result{}, fmt.Errorf("failed to create graph update pixels parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -378,7 +377,7 @@ type PixelInput struct {
 func (g *Graph) createUpdatePixelsRequestParameter(input *GraphUpdatePixelsInput) (*requestParameter, error) {
 	b, err := json.Marshal(input.Pixels)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	ID := StringValue(input.ID)
@@ -431,13 +430,13 @@ func (g *Graph) Stats(input *GraphStatsInput) (*Stats, error) {
 func (g *Graph) StatsWithContext(ctx context.Context, input *GraphStatsInput) (*Stats, error) {
 	b, status, err := doRequest(ctx, g.createStatsRequestParameter(input))
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to do request")
+		return nil, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var stats Stats
 	stats.StatusCode = status
 	if err := json.Unmarshal(b, &stats); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal json")
+		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	stats.IsSuccess = stats.Message == ""
@@ -471,7 +470,7 @@ func (g *Graph) Update(input *GraphUpdateInput) (*Result, error) {
 func (g *Graph) UpdateWithContext(ctx context.Context, input *GraphUpdateInput) (*Result, error) {
 	param, err := g.createUpdateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph update parameter")
+		return &Result{}, fmt.Errorf("failed to create graph update parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -496,7 +495,7 @@ type GraphUpdateInput struct {
 func (g *Graph) createUpdateRequestParameter(input *GraphUpdateInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	ID := StringValue(input.ID)
@@ -571,12 +570,12 @@ func (g *Graph) GetPixelDates(input *GraphGetPixelDatesInput) (*Pixels, error) {
 func (g *Graph) GetPixelDatesWithContext(ctx context.Context, input *GraphGetPixelDatesInput) (*Pixels, error) {
 	b, status, err := doRequest(ctx, g.createGetPixelDatesRequestParameter(input))
 	if err != nil {
-		return &Pixels{}, errors.Wrapf(err, "failed to do request")
+		return &Pixels{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	pixels, err := unmarshalPixels(b, BoolValue(input.WithBody))
 	if err != nil {
-		return &Pixels{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &Pixels{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	pixels.StatusCode = status
@@ -621,7 +620,7 @@ func unmarshalPixelsWithBody(b []byte) (*Pixels, error) {
 		Result
 	}
 	if err := json.Unmarshal(b, &pixels); err != nil {
-		return &Pixels{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &Pixels{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	return &Pixels{
@@ -636,7 +635,7 @@ func unmarshalPixelsNoBody(b []byte) (*Pixels, error) {
 		Result
 	}
 	if err := json.Unmarshal(b, &pixels); err != nil {
-		return &Pixels{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &Pixels{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	return &Pixels{
@@ -706,13 +705,13 @@ func (g *Graph) Get(input *GraphGetInput) (*GraphDefinition, error) {
 func (g *Graph) GetWithContext(ctx context.Context, input *GraphGetInput) (*GraphDefinition, error) {
 	b, status, err := doRequest(ctx, g.createGetRequestParameter(input))
 	if err != nil {
-		return &GraphDefinition{}, errors.Wrapf(err, "failed to do request")
+		return &GraphDefinition{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var definition GraphDefinition
 	definition.StatusCode = status
 	if err := json.Unmarshal(b, &definition); err != nil {
-		return &GraphDefinition{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &GraphDefinition{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	definition.IsSuccess = definition.Message == ""
@@ -744,7 +743,7 @@ func (g *Graph) Add(input *GraphAddInput) (*Result, error) {
 func (g *Graph) AddWithContext(ctx context.Context, input *GraphAddInput) (*Result, error) {
 	param, err := g.createAddRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph add parameter")
+		return &Result{}, fmt.Errorf("failed to create graph add parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -761,7 +760,7 @@ type GraphAddInput struct {
 func (g *Graph) createAddRequestParameter(input *GraphAddInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.ID)
@@ -782,7 +781,7 @@ func (g *Graph) Subtract(input *GraphSubtractInput) (*Result, error) {
 func (g *Graph) SubtractWithContext(ctx context.Context, input *GraphSubtractInput) (*Result, error) {
 	param, err := g.createSubtractRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create graph add parameter")
+		return &Result{}, fmt.Errorf("failed to create graph add parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -799,7 +798,7 @@ type GraphSubtractInput struct {
 func (g *Graph) createSubtractRequestParameter(input *GraphSubtractInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.ID)
@@ -820,13 +819,13 @@ func (g *Graph) Analyze(input *GraphAnalyzeInput) (*GraphAnalysis, error) {
 func (g *Graph) AnalyzeWithContext(ctx context.Context, input *GraphAnalyzeInput) (*GraphAnalysis, error) {
 	b, status, err := doRequest(ctx, g.createAnalyzeRequestParameter(input))
 	if err != nil {
-		return &GraphAnalysis{}, errors.Wrapf(err, "failed to do request")
+		return &GraphAnalysis{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var analysis GraphAnalysis
 	analysis.StatusCode = status
 	if err := json.Unmarshal(b, &analysis); err != nil {
-		return &analysis, errors.Wrapf(err, "failed to unmarshal json")
+		return &analysis, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	analysis.IsSuccess = analysis.StatusCode == http.StatusOK

--- a/pixel.go
+++ b/pixel.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 )
 
 // A Pixel manages communication with the Pixela pixel API.
@@ -24,7 +23,7 @@ func (p *Pixel) Create(input *PixelCreateInput) (*Result, error) {
 func (p *Pixel) CreateWithContext(ctx context.Context, input *PixelCreateInput) (*Result, error) {
 	param, err := p.createCreateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel create parameter")
+		return &Result{}, fmt.Errorf("failed to create pixel create parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -44,7 +43,7 @@ type PixelCreateInput struct {
 func (p *Pixel) createCreateRequestParameter(input *PixelCreateInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.GraphID)
@@ -121,13 +120,13 @@ func (p *Pixel) Get(input *PixelGetInput) (*Quantity, error) {
 func (p *Pixel) GetWithContext(ctx context.Context, input *PixelGetInput) (*Quantity, error) {
 	b, status, err := doRequest(ctx, p.createGetRequestParameter(input))
 	if err != nil {
-		return &Quantity{}, errors.Wrapf(err, "failed to do request")
+		return &Quantity{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var quantity Quantity
 	quantity.StatusCode = status
 	if err := json.Unmarshal(b, &quantity); err != nil {
-		return &Quantity{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &Quantity{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	quantity.IsSuccess = quantity.Message == ""
@@ -169,7 +168,7 @@ func (p *Pixel) Update(input *PixelUpdateInput) (*Result, error) {
 func (p *Pixel) UpdateWithContext(ctx context.Context, input *PixelUpdateInput) (*Result, error) {
 	param, err := p.createUpdateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel update parameter")
+		return &Result{}, fmt.Errorf("failed to create pixel update parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -188,7 +187,7 @@ type PixelUpdateInput struct {
 func (p *Pixel) createUpdateRequestParameter(input *PixelUpdateInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.GraphID)
@@ -210,7 +209,7 @@ func (p *Pixel) Add(input *PixelAddInput) (*Result, error) {
 func (p *Pixel) AddWithContext(ctx context.Context, input *PixelAddInput) (*Result, error) {
 	param, err := p.createAddRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel add parameter")
+		return &Result{}, fmt.Errorf("failed to create pixel add parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -229,7 +228,7 @@ type PixelAddInput struct {
 func (p *Pixel) createAddRequestParameter(input *PixelAddInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.GraphID)
@@ -251,7 +250,7 @@ func (p *Pixel) Subtract(input *PixelSubtractInput) (*Result, error) {
 func (p *Pixel) SubtractWithContext(ctx context.Context, input *PixelSubtractInput) (*Result, error) {
 	param, err := p.createSubtractRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create pixel subtract parameter")
+		return &Result{}, fmt.Errorf("failed to create pixel subtract parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -270,7 +269,7 @@ type PixelSubtractInput struct {
 func (p *Pixel) createSubtractRequestParameter(input *PixelSubtractInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	graphID := StringValue(input.GraphID)

--- a/retry.go
+++ b/retry.go
@@ -2,11 +2,11 @@ package pixela
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const maxRetryCount = 20
@@ -58,7 +58,7 @@ func (m *retryer) shouldRetry() bool {
 
 	r, err := parseNormalResponse(m.body)
 	if err != nil {
-		m.err = errors.Wrapf(err, "failed to parse normal response")
+		m.err = fmt.Errorf("failed to parse normal response: %w", err)
 		return false
 	}
 

--- a/user.go
+++ b/user.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 )
 
 // A User manages communication with the Pixela user API.
@@ -24,7 +23,7 @@ func (u *User) Create(input *UserCreateInput) (*Result, error) {
 func (u *User) CreateWithContext(ctx context.Context, input *UserCreateInput) (*Result, error) {
 	param, err := u.createCreateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create user create parameter")
+		return &Result{}, fmt.Errorf("failed to create user create parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -54,7 +53,7 @@ func (u *User) createCreateRequestParameter(input *UserCreateInput) (*requestPar
 		ThanksCode:          StringValue(input.ThanksCode),
 	})
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	return &requestParameter{
@@ -81,7 +80,7 @@ func (u *User) Update(input *UserUpdateInput) (*Result, error) {
 func (u *User) UpdateWithContext(ctx context.Context, input *UserUpdateInput) (*Result, error) {
 	param, err := u.createUpdateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create user update parameter")
+		return &Result{}, fmt.Errorf("failed to create user update parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -106,7 +105,7 @@ func (u *User) createUpdateRequestParameter(input *UserUpdateInput) (*requestPar
 		AllowAIProcessing: input.AllowAIProcessing,
 	})
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	return &requestParameter{

--- a/user_profile.go
+++ b/user_profile.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 )
 
 // A UserProfile manages communication with the Pixela user profile API.
@@ -24,7 +23,7 @@ func (u *UserProfile) Update(input *UserProfileUpdateInput) (*Result, error) {
 func (u *UserProfile) UpdateWithContext(ctx context.Context, input *UserProfileUpdateInput) (*Result, error) {
 	param, err := u.createUpdateRequestParameter(input)
 	if err != nil {
-		return &Result{}, errors.Wrapf(err, "failed to create user profile update parameter")
+		return &Result{}, fmt.Errorf("failed to create user profile update parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, param)
@@ -44,7 +43,7 @@ type UserProfileUpdateInput struct {
 func (u *UserProfile) createUpdateRequestParameter(input *UserProfileUpdateInput) (*requestParameter, error) {
 	b, err := json.Marshal(input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	return &requestParameter{

--- a/webhook.go
+++ b/webhook.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/pkg/errors"
 )
 
 // A Webhook manages communication with the Pixela webhook API.
@@ -24,18 +23,18 @@ func (w *Webhook) Create(input *WebhookCreateInput) (*WebhookCreateResult, error
 func (w *Webhook) CreateWithContext(ctx context.Context, input *WebhookCreateInput) (*WebhookCreateResult, error) {
 	param, err := w.createCreateRequestParameter(input)
 	if err != nil {
-		return &WebhookCreateResult{}, errors.Wrapf(err, "failed to create webhook create parameter")
+		return &WebhookCreateResult{}, fmt.Errorf("failed to create webhook create parameter: %w", err)
 	}
 
 	b, status, err := doRequest(ctx, param)
 	if err != nil {
-		return &WebhookCreateResult{}, errors.Wrapf(err, "failed to do request")
+		return &WebhookCreateResult{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var createResult WebhookCreateResult
 	createResult.StatusCode = status
 	if err := json.Unmarshal(b, &createResult); err != nil {
-		return &WebhookCreateResult{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &WebhookCreateResult{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	return &createResult, nil
@@ -67,7 +66,7 @@ type WebhookCreateResult struct {
 func (w *Webhook) createCreateRequestParameter(input *WebhookCreateInput) (*requestParameter, error) {
 	b, err := json.Marshal(&input)
 	if err != nil {
-		return &requestParameter{}, errors.Wrap(err, "failed to marshal json")
+		return &requestParameter{}, fmt.Errorf("failed to marshal json: %w", err)
 	}
 
 	return &requestParameter{
@@ -87,13 +86,13 @@ func (w *Webhook) GetAll() (*WebhookDefinitions, error) {
 func (w *Webhook) GetAllWithContext(ctx context.Context) (*WebhookDefinitions, error) {
 	b, status, err := doRequest(ctx, w.createGetAllRequestParameter())
 	if err != nil {
-		return &WebhookDefinitions{}, errors.Wrapf(err, "failed to do request")
+		return &WebhookDefinitions{}, fmt.Errorf("failed to do request: %w", err)
 	}
 
 	var definitions WebhookDefinitions
 	definitions.StatusCode = status
 	if err := json.Unmarshal(b, &definitions); err != nil {
-		return &WebhookDefinitions{}, errors.Wrapf(err, "failed to unmarshal json")
+		return &WebhookDefinitions{}, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
 	definitions.IsSuccess = definitions.Message == ""


### PR DESCRIPTION
## Summary

- `github.com/pkg/errors` を標準の `fmt.Errorf` + `%w` verb に置き換えた
- Go 1.13 以降はネイティブのエラーラッピングがサポートされており、サードパーティ依存が不要
- `go mod tidy` により `go.mod` / `go.sum` から `github.com/pkg/errors` を削除

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes