### PR TITLE
Inject HTTP client via Client.HTTPClient field

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,6 +9,11 @@ import (
 	"net/http"
 )
 
+// HTTPClient is an interface for making HTTP requests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // APIBaseURL is Base URL for API requests.
 const APIBaseURL = "https://pixe.la"
 
@@ -54,9 +59,9 @@ func newHTTPRequest(ctx context.Context, param *requestParameter) (*http.Request
 	return req, nil
 }
 
-func doRequest(ctx context.Context, param *requestParameter) ([]byte, int, error) {
+func doRequest(ctx context.Context, httpClient HTTPClient, param *requestParameter) ([]byte, int, error) {
 	retry := retryer{
-		processFunc: processFunc(ctx, param),
+		processFunc: processFunc(ctx, httpClient, param),
 		maxRetry:    getRetryCount(),
 	}
 	if err := retry.do(ctx); err != nil {
@@ -66,7 +71,7 @@ func doRequest(ctx context.Context, param *requestParameter) ([]byte, int, error
 	return retry.body, retry.statusCode, nil
 }
 
-func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) {
+func processFunc(ctx context.Context, httpClient HTTPClient, param *requestParameter) func(m *retryer) {
 	return func(m *retryer) {
 		req, err := newHTTPRequest(ctx, param)
 		if err != nil {
@@ -74,11 +79,7 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 			return
 		}
 
-		client := http.Client{}
-		resp, err := client.Do(req)
-		if clientMock != nil {
-			resp, err = clientMock.do(req)
-		}
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			m.err = fmt.Errorf("failed http.Client do: %w", err)
 			return
@@ -97,17 +98,13 @@ func processFunc(ctx context.Context, param *requestParameter) func(m *retryer) 
 	}
 }
 
-func mustDoRequest(ctx context.Context, param *requestParameter) ([]byte, error) {
+func mustDoRequest(ctx context.Context, httpClient HTTPClient, param *requestParameter) ([]byte, error) {
 	req, err := newHTTPRequest(ctx, param)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to create http.Request: %w", err)
 	}
 
-	client := http.Client{}
-	resp, err := client.Do(req)
-	if clientMock != nil {
-		resp, err = clientMock.do(req)
-	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed http.Client do: %w", err)
 	}
@@ -125,9 +122,9 @@ func mustDoRequest(ctx context.Context, param *requestParameter) ([]byte, error)
 	return b, nil
 }
 
-func doRequestAndParseResponse(ctx context.Context, param *requestParameter) (*Result, error) {
+func doRequestAndParseResponse(ctx context.Context, httpClient HTTPClient, param *requestParameter) (*Result, error) {
 	retry := retryer{
-		processFunc: processFunc(ctx, param),
+		processFunc: processFunc(ctx, httpClient, param),
 		maxRetry:    getRetryCount(),
 	}
 	if err := retry.do(ctx); err != nil {

--- a/client.go
+++ b/client.go
@@ -1,37 +1,44 @@
 package pixela
 
+import "net/http"
+
 // A Client manages communication with the Pixela User API.
 type Client struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	HTTPClient HTTPClient
 }
 
 // New return a new Client instance.
 func New(userName, token string) *Client {
-	return &Client{UserName: userName, Token: token}
+	return &Client{
+		UserName:   userName,
+		Token:      token,
+		HTTPClient: &http.Client{},
+	}
 }
 
 // User returns a new Pixela user API client.
 func (c *Client) User() *User {
-	return &User{UserName: c.UserName, Token: c.Token}
+	return &User{UserName: c.UserName, Token: c.Token, httpClient: c.HTTPClient}
 }
 
 // UserProfile returns a new Pixela user profile API client.
 func (c *Client) UserProfile() *UserProfile {
-	return &UserProfile{UserName: c.UserName, Token: c.Token}
+	return &UserProfile{UserName: c.UserName, Token: c.Token, httpClient: c.HTTPClient}
 }
 
 // Graph returns a new Pixela graph API client.
 func (c *Client) Graph() *Graph {
-	return &Graph{UserName: c.UserName, Token: c.Token}
+	return &Graph{UserName: c.UserName, Token: c.Token, httpClient: c.HTTPClient}
 }
 
 // Pixel returns a new Pixela pixel API client.
 func (c *Client) Pixel() *Pixel {
-	return &Pixel{UserName: c.UserName, Token: c.Token}
+	return &Pixel{UserName: c.UserName, Token: c.Token, httpClient: c.HTTPClient}
 }
 
 // Webhook returns a new Pixela webhook API client.
 func (c *Client) Webhook() *Webhook {
-	return &Webhook{UserName: c.UserName, Token: c.Token}
+	return &Webhook{UserName: c.UserName, Token: c.Token, httpClient: c.HTTPClient}
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -59,7 +59,6 @@ If you run E2E test, Set below environment variables.
 }
 
 func initE2ETest() {
-	clientMock = nil
 	RetryCount = 20
 
 	name := os.Getenv("PIXELA4GO_USER_NAME")

--- a/graph.go
+++ b/graph.go
@@ -11,8 +11,9 @@ import (
 
 // A Graph manages communication with the Pixela graph API.
 type Graph struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	httpClient HTTPClient
 }
 
 // Create creates a new pixelation graph definition.
@@ -27,7 +28,7 @@ func (g *Graph) CreateWithContext(ctx context.Context, input *GraphCreateInput) 
 		return &Result{}, fmt.Errorf("failed to create graph create parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.httpClient, param)
 }
 
 // GraphCreateInput is input of Graph.Create().
@@ -99,7 +100,7 @@ func (g *Graph) GetAll() (*GraphDefinitions, error) {
 
 // GetAllWithContext gets all predefined pixelation graph definitions.
 func (g *Graph) GetAllWithContext(ctx context.Context) (*GraphDefinitions, error) {
-	b, status, err := doRequest(ctx, g.createGetAllRequestParameter())
+	b, status, err := doRequest(ctx, g.httpClient, g.createGetAllRequestParameter())
 	if err != nil {
 		return &GraphDefinitions{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -151,7 +152,7 @@ func (g *Graph) GetLatestPixel(input *GraphGetLatestPixelInput) (*GraphPixel, er
 
 // GetLatestPixelWithContext gets the latest Pixel registered in the graph.
 func (g *Graph) GetLatestPixelWithContext(ctx context.Context, input *GraphGetLatestPixelInput) (*GraphPixel, error) {
-	b, status, err := doRequest(ctx, g.createGetLatestPixelRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createGetLatestPixelRequestParameter(input))
 	if err != nil {
 		return &GraphPixel{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -197,7 +198,7 @@ func (g *Graph) GetToday(input *GraphGetTodayInput) (*GraphPixel, error) {
 
 // GetTodayWithContext gets the Pixel registered on the day of the request.
 func (g *Graph) GetTodayWithContext(ctx context.Context, input *GraphGetTodayInput) (*GraphPixel, error) {
-	b, status, err := doRequest(ctx, g.createGetTodayRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createGetTodayRequestParameter(input))
 	if err != nil {
 		return &GraphPixel{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -256,7 +257,7 @@ func (g *Graph) GetSVG(input *GraphGetSVGInput) (string, error) {
 
 // GetSVGWithContext get a graph expressed in SVG format diagram that based on the registered information.
 func (g *Graph) GetSVGWithContext(ctx context.Context, input *GraphGetSVGInput) (string, error) {
-	b, err := mustDoRequest(ctx, g.createGetSVGRequestParameter(input))
+	b, err := mustDoRequest(ctx, g.httpClient, g.createGetSVGRequestParameter(input))
 	if err != nil {
 		return "", fmt.Errorf("failed to do request: %w", err)
 	}
@@ -355,7 +356,7 @@ func (g *Graph) UpdatePixelsWithContext(ctx context.Context, input *GraphUpdateP
 		return &Result{}, fmt.Errorf("failed to create graph update pixels parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.httpClient, param)
 }
 
 // GraphUpdatePixelsInput is input of Graph.UpdatePixels().
@@ -428,7 +429,7 @@ func (g *Graph) Stats(input *GraphStatsInput) (*Stats, error) {
 
 // StatsWithContext gets various statistics based on the registered information.
 func (g *Graph) StatsWithContext(ctx context.Context, input *GraphStatsInput) (*Stats, error) {
-	b, status, err := doRequest(ctx, g.createStatsRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createStatsRequestParameter(input))
 	if err != nil {
 		return nil, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -473,7 +474,7 @@ func (g *Graph) UpdateWithContext(ctx context.Context, input *GraphUpdateInput) 
 		return &Result{}, fmt.Errorf("failed to create graph update parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.httpClient, param)
 }
 
 // GraphUpdateInput is input of Graph.Update().
@@ -514,7 +515,7 @@ func (g *Graph) Delete(input *GraphDeleteInput) (*Result, error) {
 
 // DeleteWithContext deletes the predefined pixelation graph definition.
 func (g *Graph) DeleteWithContext(ctx context.Context, input *GraphDeleteInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, g.createDeleteRequestParameter(input))
+	return doRequestAndParseResponse(ctx, g.httpClient, g.createDeleteRequestParameter(input))
 }
 
 // GraphDeleteInput is input of Graph.Delete().
@@ -568,7 +569,7 @@ func (g *Graph) GetPixelDates(input *GraphGetPixelDatesInput) (*Pixels, error) {
 // You will get a list you specify.
 // You can not specify a period greater than 365 days.
 func (g *Graph) GetPixelDatesWithContext(ctx context.Context, input *GraphGetPixelDatesInput) (*Pixels, error) {
-	b, status, err := doRequest(ctx, g.createGetPixelDatesRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createGetPixelDatesRequestParameter(input))
 	if err != nil {
 		return &Pixels{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -677,7 +678,7 @@ func (g *Graph) Stopwatch(input *GraphStopwatchInput) (*Result, error) {
 
 // StopwatchWithContext start and end the measurement of the time.
 func (g *Graph) StopwatchWithContext(ctx context.Context, input *GraphStopwatchInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, g.createStopwatchRequestParameter(input))
+	return doRequestAndParseResponse(ctx, g.httpClient, g.createStopwatchRequestParameter(input))
 }
 
 // GraphStopwatchInput is input of Graph.Stopwatch().
@@ -703,7 +704,7 @@ func (g *Graph) Get(input *GraphGetInput) (*GraphDefinition, error) {
 
 // GetWithContext gets predefined pixelation graph definitions.
 func (g *Graph) GetWithContext(ctx context.Context, input *GraphGetInput) (*GraphDefinition, error) {
-	b, status, err := doRequest(ctx, g.createGetRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createGetRequestParameter(input))
 	if err != nil {
 		return &GraphDefinition{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -746,7 +747,7 @@ func (g *Graph) AddWithContext(ctx context.Context, input *GraphAddInput) (*Resu
 		return &Result{}, fmt.Errorf("failed to create graph add parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.httpClient, param)
 }
 
 // GraphAddInput is input of Graph.Add().
@@ -784,7 +785,7 @@ func (g *Graph) SubtractWithContext(ctx context.Context, input *GraphSubtractInp
 		return &Result{}, fmt.Errorf("failed to create graph add parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, g.httpClient, param)
 }
 
 // GraphSubtractInput is input of Graph.Subtract().
@@ -817,7 +818,7 @@ func (g *Graph) Analyze(input *GraphAnalyzeInput) (*GraphAnalysis, error) {
 
 // AnalyzeWithContext analyzes the graph by AI and returns the result.
 func (g *Graph) AnalyzeWithContext(ctx context.Context, input *GraphAnalyzeInput) (*GraphAnalysis, error) {
-	b, status, err := doRequest(ctx, g.createAnalyzeRequestParameter(input))
+	b, status, err := doRequest(ctx, g.httpClient, g.createAnalyzeRequestParameter(input))
 	if err != nil {
 		return &GraphAnalysis{}, fmt.Errorf("failed to do request: %w", err)
 	}

--- a/graph_test.go
+++ b/graph_test.go
@@ -49,9 +49,8 @@ func TestGraph_CreateCreateRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Create(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphCreateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -70,9 +69,8 @@ func TestGraph_Create(t *testing.T) {
 }
 
 func TestGraph_CreateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphCreateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -90,9 +88,8 @@ func TestGraph_CreateFail(t *testing.T) {
 }
 
 func TestGraph_CreateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphCreateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -134,9 +131,8 @@ func TestGraph_CreateGetAllRequestParameter(t *testing.T) {
 func TestGraph_GetAll(t *testing.T) {
 	s := `{"graphs":[{"id":"test-graph","name":"graph-name","unit":"commit","type":"int","color":"shibafu","timezone":"Asia/Tokyo","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx"],"selfSufficient":"increment","isSecret":true,"publishOptionalData":true}]}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	definitions, err := client.Graph().GetAll()
 	if err != nil {
 		t.Errorf("got: %v\nwant: nil", err)
@@ -165,9 +161,8 @@ func TestGraph_GetAll(t *testing.T) {
 }
 
 func TestGraph_GetAllFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	result, err := client.Graph().GetAll()
 	if err != nil {
 		t.Errorf("got: %v\nwant: nil", result)
@@ -177,9 +172,8 @@ func TestGraph_GetAllFail(t *testing.T) {
 }
 
 func TestGraph_GetAllError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	_, err := client.Graph().GetAll()
 
 	testPageNotFoundError(t, err)
@@ -213,9 +207,8 @@ func TestGraph_CreateGetLatestPixelRequestParameter(t *testing.T) {
 func TestGraph_GetLatestPixel(t *testing.T) {
 	s := `{"date":"20240414","quantity":"5","optionalData":"{\"key\":\"value\"}"}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetLatestPixelInput{
 		ID: String(graphID),
 	}
@@ -236,9 +229,8 @@ func TestGraph_GetLatestPixel(t *testing.T) {
 }
 
 func TestGraph_GetLatestPixelError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphGetLatestPixelInput{
 		ID: String(graphID),
 	}
@@ -310,9 +302,8 @@ func TestGraph_CreateGetTodayRequestParameter(t *testing.T) {
 func TestGraph_GetToday(t *testing.T) {
 	s := `{"date":"20240414","quantity":"5","optionalData":"{\"key\":\"value\"}"}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetTodayInput{
 		ID: String(graphID),
 	}
@@ -333,9 +324,8 @@ func TestGraph_GetToday(t *testing.T) {
 }
 
 func TestGraph_GetTodayError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphGetTodayInput{
 		ID: String(graphID),
 	}
@@ -410,9 +400,8 @@ func TestGraph_CreateGetSVGRequestParameter(t *testing.T) {
 func TestGraph_GetSVG(t *testing.T) {
 	s := `<svg></svg>`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetSVGInput{
 		ID:   String(graphID),
 		Date: String("20180101"),
@@ -430,16 +419,16 @@ func TestGraph_GetSVG(t *testing.T) {
 }
 
 func TestGraph_GetSVGFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
+	mock := newAPIFailedMock()
 	client := New(userName, token)
+	client.HTTPClient = mock
 	input := &GraphGetSVGInput{
 		ID:   String(graphID),
 		Date: String("20180101"),
 		Mode: String(GraphModeShort),
 	}
 	_, err := client.Graph().GetSVG(input)
-	expect := "failed to do request: failed to call API: " + string(clientMock.body)
+	expect := "failed to do request: failed to call API: " + string(mock.body)
 	if err == nil {
 		t.Errorf("got: nil\nwant: %s", expect)
 	}
@@ -492,9 +481,8 @@ func TestGraph_CreateUpdatePixelsRequestParameter(t *testing.T) {
 }
 
 func TestGraph_UpdatePixels(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphUpdatePixelsInput{
 		ID:     String(graphID),
 		Pixels: []PixelInput{},
@@ -505,9 +493,8 @@ func TestGraph_UpdatePixels(t *testing.T) {
 }
 
 func TestGraph_UpdatePixelsFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphUpdatePixelsInput{
 		ID:     String(graphID),
 		Pixels: []PixelInput{},
@@ -518,9 +505,8 @@ func TestGraph_UpdatePixelsFail(t *testing.T) {
 }
 
 func TestGraph_UpdatePixelsError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphUpdatePixelsInput{
 		ID:     String(graphID),
 		Pixels: []PixelInput{},
@@ -574,9 +560,8 @@ func TestGraph_CreateStatsRequestParameter(t *testing.T) {
 func TestGraph_Stats(t *testing.T) {
 	s := `{"totalPixelsCount":1,"maxQuantity":2,"maxDate":"2023-09-01","minQuantity":3,"minDate":"2023-09-02","totalQuantity":4,"avgQuantity":5.0,"todaysQuantity":6,"yesterdayQuantity":66}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphStatsInput{ID: String(graphID)}
 	stats, err := client.Graph().Stats(input)
 	if err != nil {
@@ -601,9 +586,8 @@ func TestGraph_Stats(t *testing.T) {
 }
 
 func TestGraph_StatsFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphStatsInput{ID: String(graphID)}
 	result, err := client.Graph().Stats(input)
 	if err != nil {
@@ -614,9 +598,8 @@ func TestGraph_StatsFail(t *testing.T) {
 }
 
 func TestGraph_StatsError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphStatsInput{ID: String(graphID)}
 	_, err := client.Graph().Stats(input)
 
@@ -664,9 +647,8 @@ func TestGraph_CreateUpdateRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Update(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphUpdateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -685,9 +667,8 @@ func TestGraph_Update(t *testing.T) {
 }
 
 func TestGraph_UpdateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphUpdateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -705,9 +686,8 @@ func TestGraph_UpdateFail(t *testing.T) {
 }
 
 func TestGraph_UpdateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphUpdateInput{
 		ID:                  String(graphID),
 		Name:                String("name"),
@@ -748,9 +728,8 @@ func TestGraph_CreateDeleteRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Delete(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphDeleteInput{ID: String(graphID)}
 	result, err := client.Graph().Delete(input)
 
@@ -758,9 +737,8 @@ func TestGraph_Delete(t *testing.T) {
 }
 
 func TestGraph_DeleteFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphDeleteInput{ID: String(graphID)}
 	result, err := client.Graph().Delete(input)
 
@@ -768,9 +746,8 @@ func TestGraph_DeleteFail(t *testing.T) {
 }
 
 func TestGraph_DeleteError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphDeleteInput{ID: String(graphID)}
 	_, err := client.Graph().Delete(input)
 
@@ -808,9 +785,8 @@ func TestGraph_CreateGetPixelDatesRequestParameter(t *testing.T) {
 func TestGraph_GetPixelDates(t *testing.T) {
 	s := `{"pixels":["20180101","20180331"]}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetPixelDatesInput{ID: String(graphID), From: String("20180101"), To: String("20181231")}
 	pixels, err := client.Graph().GetPixelDates(input)
 	if err != nil {
@@ -829,9 +805,8 @@ func TestGraph_GetPixelDates(t *testing.T) {
 func TestGraph_GetPixelDatesWithBody(t *testing.T) {
 	s := `{"pixels":[{"date":"20180331","quantity":"1","optionalData":"{\"key\":\"value\"}"}]}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetPixelDatesInput{
 		ID:       String(graphID),
 		From:     String("20180101"),
@@ -859,9 +834,8 @@ func TestGraph_GetPixelDatesWithBody(t *testing.T) {
 }
 
 func TestGraph_GetPixelDatesFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphGetPixelDatesInput{ID: String(graphID), From: String("20180101"), To: String("20181231")}
 	result, err := client.Graph().GetPixelDates(input)
 	if err != nil {
@@ -872,9 +846,8 @@ func TestGraph_GetPixelDatesFail(t *testing.T) {
 }
 
 func TestGraph_GetPixelDatesError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphGetPixelDatesInput{ID: String(graphID), From: String("20180101"), To: String("20181231")}
 	_, err := client.Graph().GetPixelDates(input)
 
@@ -908,9 +881,8 @@ func TestGraph_CreateStopwatchRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Stopwatch(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphStopwatchInput{ID: String(graphID)}
 	result, err := client.Graph().Stopwatch(input)
 
@@ -918,9 +890,8 @@ func TestGraph_Stopwatch(t *testing.T) {
 }
 
 func TestGraph_StopwatchFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphStopwatchInput{ID: String(graphID)}
 	result, err := client.Graph().Stopwatch(input)
 
@@ -928,9 +899,8 @@ func TestGraph_StopwatchFail(t *testing.T) {
 }
 
 func TestGraph_StopwatchError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphStopwatchInput{ID: String(graphID)}
 	_, err := client.Graph().Stopwatch(input)
 
@@ -962,9 +932,8 @@ func TestGraph_CreateGetRequestParameter(t *testing.T) {
 func TestGraph_Get(t *testing.T) {
 	s := `{"id":"test-graph","name":"graph-name","unit":"commit","type":"int","color":"shibafu","timezone":"Asia/Tokyo","purgeCacheURLs":["https://camo.githubusercontent.com/xxx/xxxx"],"selfSufficient":"increment","isSecret":true,"publishOptionalData":true}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphGetInput{ID: String(graphID)}
 	definition, err := client.Graph().Get(input)
 	if err != nil {
@@ -990,9 +959,8 @@ func TestGraph_Get(t *testing.T) {
 }
 
 func TestGraph_GetFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphGetInput{ID: String(graphID)}
 	result, err := client.Graph().Get(input)
 	if err != nil {
@@ -1003,9 +971,8 @@ func TestGraph_GetFail(t *testing.T) {
 }
 
 func TestGraph_GetError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphGetInput{ID: String(graphID)}
 	_, err := client.Graph().Get(input)
 
@@ -1044,9 +1011,8 @@ func TestGraph_CreateAddRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Add(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphAddInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1057,9 +1023,8 @@ func TestGraph_Add(t *testing.T) {
 }
 
 func TestGraph_AddFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphAddInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1070,9 +1035,8 @@ func TestGraph_AddFail(t *testing.T) {
 }
 
 func TestGraph_AddError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphAddInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1114,9 +1078,8 @@ func TestGraph_CreateSubtractRequestParameter(t *testing.T) {
 }
 
 func TestGraph_Subtract(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &GraphSubtractInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1127,9 +1090,8 @@ func TestGraph_Subtract(t *testing.T) {
 }
 
 func TestGraph_SubtractFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphSubtractInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1140,9 +1102,8 @@ func TestGraph_SubtractFail(t *testing.T) {
 }
 
 func TestGraph_SubtractError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphSubtractInput{
 		ID:       String(graphID),
 		Quantity: String("1"),
@@ -1178,9 +1139,8 @@ func TestGraph_CreateAnalyzeRequestParameter(t *testing.T) {
 func TestGraph_Analyze(t *testing.T) {
 	s := `{"analysis":"This graph shows a consistent upward trend."}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &GraphAnalyzeInput{
 		ID: String(graphID),
 	}
@@ -1199,9 +1159,8 @@ func TestGraph_Analyze(t *testing.T) {
 }
 
 func TestGraph_AnalyzeFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &GraphAnalyzeInput{
 		ID: String(graphID),
 	}
@@ -1216,9 +1175,8 @@ func TestGraph_AnalyzeFail(t *testing.T) {
 }
 
 func TestGraph_AnalyzeError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &GraphAnalyzeInput{
 		ID: String(graphID),
 	}

--- a/pixel.go
+++ b/pixel.go
@@ -10,8 +10,9 @@ import (
 
 // A Pixel manages communication with the Pixela pixel API.
 type Pixel struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	httpClient HTTPClient
 }
 
 // Create records the quantity of the specified date as a "Pixel".
@@ -26,7 +27,7 @@ func (p *Pixel) CreateWithContext(ctx context.Context, input *PixelCreateInput) 
 		return &Result{}, fmt.Errorf("failed to create pixel create parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.httpClient, param)
 }
 
 // PixelCreateInput is input of Pixel.Create().
@@ -64,7 +65,7 @@ func (p *Pixel) Increment(input *PixelIncrementInput) (*Result, error) {
 // IncrementWithContext increments quantity "Pixel" of the day (it is used "timezone" setting if Graph's "timezone" is specified, if not specified, calculates it in "UTC").
 // If the graph type is int then 1 added, and for float then 0.01 added.
 func (p *Pixel) IncrementWithContext(ctx context.Context, input *PixelIncrementInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, p.createIncrementRequestParameter(input))
+	return doRequestAndParseResponse(ctx, p.httpClient, p.createIncrementRequestParameter(input))
 }
 
 // PixelIncrementInput is input of Pixel.Increment().
@@ -92,7 +93,7 @@ func (p *Pixel) Decrement(input *PixelDecrementInput) (*Result, error) {
 // DecrementWithContext decrements quantity "Pixel" of the day (it is used "timezone" setting if Graph's "timezone" is specified, if not specified, calculates it in "UTC").
 // If the graph type is int then -1 added, and for float then -0.01 added.
 func (p *Pixel) DecrementWithContext(ctx context.Context, input *PixelDecrementInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, p.createDecrementRequestParameter(input))
+	return doRequestAndParseResponse(ctx, p.httpClient, p.createDecrementRequestParameter(input))
 }
 
 // PixelDecrementInput is input of Pixel.Decrement().
@@ -118,7 +119,7 @@ func (p *Pixel) Get(input *PixelGetInput) (*Quantity, error) {
 
 // GetWithContext gets registered quantity as "Pixel".
 func (p *Pixel) GetWithContext(ctx context.Context, input *PixelGetInput) (*Quantity, error) {
-	b, status, err := doRequest(ctx, p.createGetRequestParameter(input))
+	b, status, err := doRequest(ctx, p.httpClient, p.createGetRequestParameter(input))
 	if err != nil {
 		return &Quantity{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -171,7 +172,7 @@ func (p *Pixel) UpdateWithContext(ctx context.Context, input *PixelUpdateInput) 
 		return &Result{}, fmt.Errorf("failed to create pixel update parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.httpClient, param)
 }
 
 // PixelUpdateInput is input of Pixel.Update().
@@ -212,7 +213,7 @@ func (p *Pixel) AddWithContext(ctx context.Context, input *PixelAddInput) (*Resu
 		return &Result{}, fmt.Errorf("failed to create pixel add parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.httpClient, param)
 }
 
 // PixelAddInput is input of Pixel.Add().
@@ -253,7 +254,7 @@ func (p *Pixel) SubtractWithContext(ctx context.Context, input *PixelSubtractInp
 		return &Result{}, fmt.Errorf("failed to create pixel subtract parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, p.httpClient, param)
 }
 
 // PixelSubtractInput is input of Pixel.Subtract().
@@ -289,7 +290,7 @@ func (p *Pixel) Delete(input *PixelDeleteInput) (*Result, error) {
 
 // DeleteWithContext deletes the registered "Pixel".
 func (p *Pixel) DeleteWithContext(ctx context.Context, input *PixelDeleteInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, p.createDeleteRequestParameter(input))
+	return doRequestAndParseResponse(ctx, p.httpClient, p.createDeleteRequestParameter(input))
 }
 
 // PixelDeleteInput is input of Pixel.Delete().

--- a/pixel_test.go
+++ b/pixel_test.go
@@ -41,9 +41,8 @@ func TestPixel_CreateCreateRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Create(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelCreateInput{Date: String("20180915"), Quantity: String("5"), GraphID: String(graphID)}
 	result, err := client.Pixel().Create(input)
 
@@ -51,9 +50,8 @@ func TestPixel_Create(t *testing.T) {
 }
 
 func TestPixel_CreateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelCreateInput{Date: String("20180915"), Quantity: String("5"), GraphID: String(graphID)}
 	result, err := client.Pixel().Create(input)
 
@@ -61,9 +59,8 @@ func TestPixel_CreateFail(t *testing.T) {
 }
 
 func TestPixel_CreateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelCreateInput{Date: String("20180915"), Quantity: String("5"), GraphID: String(graphID)}
 	_, err := client.Pixel().Create(input)
 
@@ -97,9 +94,8 @@ func TestPixel_CreateIncrementRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Increment(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelIncrementInput{GraphID: String(graphID)}
 	result, err := client.Pixel().Increment(input)
 
@@ -107,9 +103,8 @@ func TestPixel_Increment(t *testing.T) {
 }
 
 func TestPixel_IncrementFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelIncrementInput{GraphID: String(graphID)}
 	result, err := client.Pixel().Increment(input)
 
@@ -117,9 +112,8 @@ func TestPixel_IncrementFail(t *testing.T) {
 }
 
 func TestPixel_IncrementError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelIncrementInput{GraphID: String(graphID)}
 	_, err := client.Pixel().Increment(input)
 
@@ -149,9 +143,8 @@ func TestPixel_CreateDecrementRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Decrement(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelDecrementInput{GraphID: String(graphID)}
 	result, err := client.Pixel().Decrement(input)
 
@@ -159,9 +152,8 @@ func TestPixel_Decrement(t *testing.T) {
 }
 
 func TestPixel_DecrementFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelDecrementInput{GraphID: String(graphID)}
 	result, err := client.Pixel().Decrement(input)
 
@@ -169,9 +161,8 @@ func TestPixel_DecrementFail(t *testing.T) {
 }
 
 func TestPixel_DecrementError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelDecrementInput{GraphID: String(graphID)}
 	_, err := client.Pixel().Decrement(input)
 
@@ -204,9 +195,8 @@ func TestPixel_CreateGetRequestParameter(t *testing.T) {
 func TestPixel_Get(t *testing.T) {
 	s := `{"quantity": "5","optionalData":"{\"key\":\"value\"}"}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &PixelGetInput{GraphID: String(graphID), Date: String("20180915")}
 	quantity, err := client.Pixel().Get(input)
 	if err != nil {
@@ -224,9 +214,8 @@ func TestPixel_Get(t *testing.T) {
 }
 
 func TestPixel_GetFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelGetInput{GraphID: String(graphID), Date: String("20180915")}
 	result, err := client.Pixel().Get(input)
 
@@ -234,9 +223,8 @@ func TestPixel_GetFail(t *testing.T) {
 }
 
 func TestPixel_GetError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelGetInput{GraphID: String(graphID), Date: String("20180915")}
 	_, err := client.Pixel().Get(input)
 
@@ -277,9 +265,8 @@ func TestPixel_CreateUpdateRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Update(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelUpdateInput{
 		GraphID:  String(graphID),
 		Date:     String("20180915"),
@@ -291,9 +278,8 @@ func TestPixel_Update(t *testing.T) {
 }
 
 func TestPixel_UpdateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelUpdateInput{
 		GraphID:  String(graphID),
 		Date:     String("20180915"),
@@ -305,9 +291,8 @@ func TestPixel_UpdateFail(t *testing.T) {
 }
 
 func TestPixel_UpdateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelUpdateInput{
 		GraphID:  String(graphID),
 		Date:     String("20180915"),
@@ -351,9 +336,8 @@ func TestPixel_CreateAddRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Add(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
 	result, err := client.Pixel().Add(input)
 
@@ -361,9 +345,8 @@ func TestPixel_Add(t *testing.T) {
 }
 
 func TestPixel_AddFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
 	result, err := client.Pixel().Add(input)
 
@@ -371,9 +354,8 @@ func TestPixel_AddFail(t *testing.T) {
 }
 
 func TestPixel_AddError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelAddInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("5")}
 	_, err := client.Pixel().Add(input)
 
@@ -413,9 +395,8 @@ func TestPixel_CreateSubtractRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Subtract(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
 	result, err := client.Pixel().Subtract(input)
 
@@ -423,9 +404,8 @@ func TestPixel_Subtract(t *testing.T) {
 }
 
 func TestPixel_SubtractFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
 	result, err := client.Pixel().Subtract(input)
 
@@ -433,9 +413,8 @@ func TestPixel_SubtractFail(t *testing.T) {
 }
 
 func TestPixel_SubtractError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelSubtractInput{GraphID: String(graphID), Date: String("20180915"), Quantity: String("3")}
 	_, err := client.Pixel().Subtract(input)
 
@@ -466,9 +445,8 @@ func TestPixel_CreateDeleteRequestParameter(t *testing.T) {
 }
 
 func TestPixel_Delete(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}
 	result, err := client.Pixel().Delete(input)
 
@@ -476,9 +454,8 @@ func TestPixel_Delete(t *testing.T) {
 }
 
 func TestPixel_DeleteFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}
 	result, err := client.Pixel().Delete(input)
 
@@ -486,9 +463,8 @@ func TestPixel_DeleteFail(t *testing.T) {
 }
 
 func TestPixel_DeleteError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &PixelDeleteInput{GraphID: String(graphID), Date: String("20180915")}
 	_, err := client.Pixel().Delete(input)
 

--- a/test_common.go
+++ b/test_common.go
@@ -19,14 +19,12 @@ type httpClientMock struct {
 	body       []byte
 }
 
-func (c *httpClientMock) do(req *http.Request) (*http.Response, error) {
+func (c *httpClientMock) Do(req *http.Request) (*http.Response, error) {
 	resp := &http.Response{}
 	resp.StatusCode = c.statusCode
 	resp.Body = io.NopCloser(bytes.NewReader(c.body))
 	return resp, nil
 }
-
-var clientMock *httpClientMock
 
 func newOKMock() *httpClientMock {
 	return &httpClientMock{

--- a/user.go
+++ b/user.go
@@ -10,8 +10,9 @@ import (
 
 // A User manages communication with the Pixela user API.
 type User struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	httpClient HTTPClient
 }
 
 // Create creates a new Pixela user.
@@ -26,7 +27,7 @@ func (u *User) CreateWithContext(ctx context.Context, input *UserCreateInput) (*
 		return &Result{}, fmt.Errorf("failed to create user create parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, u.httpClient, param)
 }
 
 // UserCreateInput is input of User.Create().
@@ -83,7 +84,7 @@ func (u *User) UpdateWithContext(ctx context.Context, input *UserUpdateInput) (*
 		return &Result{}, fmt.Errorf("failed to create user update parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, u.httpClient, param)
 }
 
 // UserUpdateInput is input of User.Update().
@@ -123,7 +124,7 @@ func (u *User) Delete() (*Result, error) {
 
 // DeleteWithContext deletes the specified registered user.
 func (u *User) DeleteWithContext(ctx context.Context) (*Result, error) {
-	return doRequestAndParseResponse(ctx, u.createDeleteRequestParameter())
+	return doRequestAndParseResponse(ctx, u.httpClient, u.createDeleteRequestParameter())
 }
 
 func (u *User) createDeleteRequestParameter() *requestParameter {

--- a/user_profile.go
+++ b/user_profile.go
@@ -10,8 +10,9 @@ import (
 
 // A UserProfile manages communication with the Pixela user profile API.
 type UserProfile struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	httpClient HTTPClient
 }
 
 // Update updates the profile information for the user corresponding to username.
@@ -26,7 +27,7 @@ func (u *UserProfile) UpdateWithContext(ctx context.Context, input *UserProfileU
 		return &Result{}, fmt.Errorf("failed to create user profile update parameter: %w", err)
 	}
 
-	return doRequestAndParseResponse(ctx, param)
+	return doRequestAndParseResponse(ctx, u.httpClient, param)
 }
 
 // UserProfileUpdateInput is input of UserProfile.Update().

--- a/user_profile_test.go
+++ b/user_profile_test.go
@@ -44,9 +44,8 @@ func TestCreateUserProfileUpdateRequestParameter(t *testing.T) {
 }
 
 func TestUserProfileUpdate(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &UserProfileUpdateInput{
 		DisplayName:       String("displayName"),
 		GravatarIconEmail: String("gravatarIconEmail"),
@@ -62,9 +61,8 @@ func TestUserProfileUpdate(t *testing.T) {
 }
 
 func TestUserProfileUpdateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &UserProfileUpdateInput{
 		DisplayName:       String("displayName"),
 		GravatarIconEmail: String("gravatarIconEmail"),
@@ -80,9 +78,8 @@ func TestUserProfileUpdateFail(t *testing.T) {
 }
 
 func TestUserProfileUpdateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &UserProfileUpdateInput{
 		DisplayName:       String("displayName"),
 		GravatarIconEmail: String("gravatarIconEmail"),

--- a/user_test.go
+++ b/user_test.go
@@ -36,9 +36,8 @@ func TestCreateUserCreateRequestParameter(t *testing.T) {
 }
 
 func TestUserCreate(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &UserCreateInput{
 		AgreeTermsOfService: Bool(true),
 		NotMinor:            Bool(true),
@@ -50,9 +49,8 @@ func TestUserCreate(t *testing.T) {
 }
 
 func TestUserCreateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &UserCreateInput{
 		AgreeTermsOfService: Bool(true),
 		NotMinor:            Bool(true),
@@ -64,9 +62,8 @@ func TestUserCreateFail(t *testing.T) {
 }
 
 func TestUserCreateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &UserCreateInput{
 		AgreeTermsOfService: Bool(true),
 		NotMinor:            Bool(true),
@@ -110,9 +107,8 @@ func TestCreateUserUpdateRequestParameter(t *testing.T) {
 }
 
 func TestUserUpdate(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &UserUpdateInput{
 		NewToken:   String("newToken"),
 		ThanksCode: String("thanks-code"),
@@ -123,9 +119,8 @@ func TestUserUpdate(t *testing.T) {
 }
 
 func TestUserUpdateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &UserUpdateInput{
 		NewToken:   String("newToken"),
 		ThanksCode: String("thanks-code"),
@@ -140,9 +135,8 @@ func TestUserUpdateFail(t *testing.T) {
 }
 
 func TestUserUpdateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &UserUpdateInput{
 		NewToken:   String("newToken"),
 		ThanksCode: String("thanks-code"),
@@ -179,27 +173,24 @@ func TestCreateUserDeleteRequestParameter(t *testing.T) {
 }
 
 func TestUserDelete(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	result, err := client.User().Delete()
 
 	testSuccess(t, result, err)
 }
 
 func TestUserDeleteFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	result, err := client.User().Delete()
 
 	testAPIFailedResult(t, result, err)
 }
 
 func TestUserDeleteError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	_, err := client.User().Delete()
 
 	testPageNotFoundError(t, err)

--- a/webhook.go
+++ b/webhook.go
@@ -10,8 +10,9 @@ import (
 
 // A Webhook manages communication with the Pixela webhook API.
 type Webhook struct {
-	UserName string
-	Token    string
+	UserName   string
+	Token      string
+	httpClient HTTPClient
 }
 
 // Create create a new Webhook.
@@ -26,7 +27,7 @@ func (w *Webhook) CreateWithContext(ctx context.Context, input *WebhookCreateInp
 		return &WebhookCreateResult{}, fmt.Errorf("failed to create webhook create parameter: %w", err)
 	}
 
-	b, status, err := doRequest(ctx, param)
+	b, status, err := doRequest(ctx, w.httpClient, param)
 	if err != nil {
 		return &WebhookCreateResult{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -84,7 +85,7 @@ func (w *Webhook) GetAll() (*WebhookDefinitions, error) {
 
 // GetAllWithContext get all predefined webhooks definitions.
 func (w *Webhook) GetAllWithContext(ctx context.Context) (*WebhookDefinitions, error) {
-	b, status, err := doRequest(ctx, w.createGetAllRequestParameter())
+	b, status, err := doRequest(ctx, w.httpClient, w.createGetAllRequestParameter())
 	if err != nil {
 		return &WebhookDefinitions{}, fmt.Errorf("failed to do request: %w", err)
 	}
@@ -128,7 +129,7 @@ func (w *Webhook) Delete(input *WebhookDeleteInput) (*Result, error) {
 
 // DeleteWithContext delete the registered Webhook.
 func (w *Webhook) DeleteWithContext(ctx context.Context, input *WebhookDeleteInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, w.createDeleteRequestParameter(input))
+	return doRequestAndParseResponse(ctx, w.httpClient, w.createDeleteRequestParameter(input))
 }
 
 // WebhookDeleteInput is input of Webhook.Delete().
@@ -156,7 +157,7 @@ func (w *Webhook) Invoke(input *WebhookInvokeInput) (*Result, error) {
 // InvokeWithContext invoke the webhook registered in advance.
 // It is used "timezone" setting as post date if Graph's "timezone" is specified, if not specified, calculates it in "UTC".
 func (w *Webhook) InvokeWithContext(ctx context.Context, input *WebhookInvokeInput) (*Result, error) {
-	return doRequestAndParseResponse(ctx, w.createInvokeRequestParameter(input))
+	return doRequestAndParseResponse(ctx, w.httpClient, w.createInvokeRequestParameter(input))
 }
 
 // WebhookInvokeInput is input of Webhook.Invoke().

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -42,9 +42,8 @@ func TestWebhook_CreateCreateRequestParameter(t *testing.T) {
 func TestWebhook_Create(t *testing.T) {
 	s := `{"webhookHash":"webhook-hash","message":"Success.","isSuccess":true}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	input := &WebhookCreateInput{
 		GraphID: String(graphID),
 		Type:    String(WebhookTypeIncrement),
@@ -64,9 +63,8 @@ func TestWebhook_Create(t *testing.T) {
 }
 
 func TestWebhook_CreateFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &WebhookCreateInput{
 		GraphID: String(graphID),
 		Type:    String(WebhookTypeIncrement),
@@ -77,9 +75,8 @@ func TestWebhook_CreateFail(t *testing.T) {
 }
 
 func TestWebhook_CreateError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &WebhookCreateInput{
 		GraphID: String(graphID),
 		Type:    String(WebhookTypeIncrement),
@@ -114,9 +111,8 @@ func TestCreateWebhook_GetAllRequestParameter(t *testing.T) {
 func TestWebhook_GetAll(t *testing.T) {
 	s := `{"webhooks":[{"webhookHash":"webhook-hash","graphID":"test-graph","type":"increment"}]}`
 	b := []byte(s)
-	clientMock = &httpClientMock{statusCode: http.StatusOK, body: b}
-
 	client := New(userName, token)
+	client.HTTPClient = &httpClientMock{statusCode: http.StatusOK, body: b}
 	definitions, err := client.Webhook().GetAll()
 	if err != nil {
 		t.Errorf("got: %v\nwant: nil", err)
@@ -138,18 +134,16 @@ func TestWebhook_GetAll(t *testing.T) {
 }
 
 func TestWebhook_GetAllFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	result, err := client.Webhook().GetAll()
 
 	testAPIFailedResult(t, &result.Result, err)
 }
 
 func TestWebhook_GetAllError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	_, err := client.Webhook().GetAll()
 
 	testPageNotFoundError(t, err)
@@ -179,9 +173,8 @@ func TestWebhook_CreateDeleteRequestParameter(t *testing.T) {
 }
 
 func TestWebhook_Delete(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &WebhookDeleteInput{WebhookHash: String("webhook-hash")}
 	result, err := client.Webhook().Delete(input)
 
@@ -189,9 +182,8 @@ func TestWebhook_Delete(t *testing.T) {
 }
 
 func TestWebhook_DeleteFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &WebhookDeleteInput{WebhookHash: String("webhook-hash")}
 	result, err := client.Webhook().Delete(input)
 
@@ -199,9 +191,8 @@ func TestWebhook_DeleteFail(t *testing.T) {
 }
 
 func TestWebhook_DeleteError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &WebhookDeleteInput{WebhookHash: String("webhook-hash")}
 	_, err := client.Webhook().Delete(input)
 
@@ -232,9 +223,8 @@ func TestWebhook_CreateInvokeRequestParameter(t *testing.T) {
 }
 
 func TestWebhook_Invoke(t *testing.T) {
-	clientMock = newOKMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newOKMock()
 	input := &WebhookInvokeInput{WebhookHash: String("webhook-hash")}
 	result, err := client.Webhook().Invoke(input)
 
@@ -242,9 +232,8 @@ func TestWebhook_Invoke(t *testing.T) {
 }
 
 func TestWebhook_InvokeFail(t *testing.T) {
-	clientMock = newAPIFailedMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newAPIFailedMock()
 	input := &WebhookInvokeInput{WebhookHash: String("webhook-hash")}
 	result, err := client.Webhook().Invoke(input)
 
@@ -252,9 +241,8 @@ func TestWebhook_InvokeFail(t *testing.T) {
 }
 
 func TestWebhook_InvokeError(t *testing.T) {
-	clientMock = newPageNotFoundMock()
-
 	client := New(userName, token)
+	client.HTTPClient = newPageNotFoundMock()
 	input := &WebhookInvokeInput{WebhookHash: String("webhook-hash")}
 	_, err := client.Webhook().Invoke(input)
 


### PR DESCRIPTION
## Summary

- `Client` に公開フィールド `HTTPClient HTTPClient` を追加し、`New()` で `&http.Client{}` をデフォルト値として設定
- サブクライアント（`User` / `UserProfile` / `Graph` / `Pixel` / `Webhook`）に非公開フィールド `httpClient HTTPClient` を追加し、ファクトリメソッド経由で伝播
- `doRequest` / `doRequestAndParseResponse` / `mustDoRequest` / `processFunc` に `HTTPClient` 引数を追加
- プロダクションコードから `if clientMock != nil` テスト専用分岐を削除
- `test_common.go` のパッケージグローバル `var clientMock` を削除し、`httpClientMock.do` → `Do` にリネームして `HTTPClient` インターフェースを実装
- 各テストで `clientMock = xxx` → `client.HTTPClient = xxx` パターンに変更
- E2E テストの `clientMock = nil` を削除（デフォルトで実際の `http.Client` が使われる）

## Test plan

- [x] `go build ./...` passes
- [x] `make test` passes