### PR TITLE
docs: introduce Conventional Commits convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,25 @@ WebhookTypeAdd / Increment / Decrement / Stopwatch / Subtract
 ```
 issue/:id   e.g. issue/42/add-graph-foo
 ```
+
+## Commit Convention
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/). Format:
+
+```
+<type>[(<scope>)]: <description>
+```
+
+Scope is optional. When used, it should be the domain being changed: `graph`, `pixel`, `user`, `user-profile`, `webhook`, `api`, `retry`, `util`.
+
+| Type | When to use | Example |
+|---|---|---|
+| `feat` | New public method or input field | `feat(graph): add Graph.Analyze method` |
+| `fix` | Wrong URL, HTTP method, field name, IsSuccess logic | `fix(pixel): use correct endpoint for Decrement` |
+| `docs` | README, AGENTS.md, godoc comments | `docs: add commit convention section` |
+| `refactor` | Internal restructuring, no behavior change | `refactor(api): replace internal types with anonymous structs` |
+| `test` | Unit/E2E test additions or changes only | `test(graph): add TestGraph_Analyze` |
+| `chore` | Dependency updates, stdlib migrations, Makefile, go.mod | `chore: replace ioutil with io package` |
+| `ci` | `.github/workflows/` changes | `ci: upgrade setup-go to v4` |
+
+For breaking changes (removed method, changed signature), append `!` after the type (`feat!:`) or add a `BREAKING CHANGE:` footer.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,22 @@ func main() {
 3. Change codes
 4. Run test suite with the `make test` command and confirm that it passes
 5. Run `make fmt`
-6. Commit your changes (`git commit -am 'Add some feature'`)
+6. Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/) format
 7. Create new Pull Request
+
+### Commit Types
+
+| Type | Description |
+|---|---|
+| `feat` | Add a new API method or input field |
+| `fix` | Fix incorrect behavior (wrong URL, HTTP method, field handling, etc.) |
+| `docs` | Documentation changes only (README, AGENTS.md, godoc comments) |
+| `refactor` | Internal restructuring without behavior changes |
+| `test` | Add or modify tests without changing production code |
+| `chore` | Dependency updates, stdlib migrations, Makefile, go.mod changes |
+| `ci` | Changes to CI configuration (`.github/workflows/`) |
+
+For breaking changes, append `!` after the type (`feat!:`) or add a `BREAKING CHANGE:` footer.
 
 ## License
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -139,8 +139,22 @@ func main() {
 3. コードを変更します
 4. `make test` でテストを実行し, パスすることを確認します
 5. `make fmt` でコードをフォーマットします
-6. 変更をコミットします (`git commit -am 'Add some feature'`)
+6. [Conventional Commits](https://www.conventionalcommits.org/) の形式で変更をコミットします
 7. 新しいプルリクエストを作成します
+
+### コミットの種類
+
+| Type | 説明 |
+|---|---|
+| `feat` | 新しい API メソッドや入力フィールドの追加 |
+| `fix` | 誤った動作の修正（URL・HTTP メソッド・フィールド処理の誤りなど） |
+| `docs` | ドキュメントのみの変更（README・AGENTS.md・godoc コメント） |
+| `refactor` | 動作を変えない内部構造の整理 |
+| `test` | プロダクションコードを変更しないテストの追加・修正 |
+| `chore` | 依存ライブラリの更新・置き換え、標準ライブラリへの移行、Makefile・go.mod の変更 |
+| `ci` | CI 設定の変更（`.github/workflows/`） |
+
+破壊的変更の場合は、type の後に `!` を付けるか（`feat!:`）、フッターに `BREAKING CHANGE:` を記載してください。
 
 ## ライセンス
 


### PR DESCRIPTION
## Summary

- Update step 6 in the Contribution section of README.md and README_ja.md to reference [Conventional Commits](https://www.conventionalcommits.org/)
- Add a commit type table (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`) to both README files
- Add a `## Commit Convention` section to AGENTS.md with scope guidance and project-specific examples for each type

## Test plan

- [ ] Documentation-only change; no functional code modified
- [ ] Verify the commit type table renders correctly in both README.md and README_ja.md
- [ ] Verify the AGENTS.md section is consistent with the README tables