### PR TITLE
fix: minor fixes (error message, mustDoRequest retry, SVG input json tags)

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,27 +99,19 @@ func processFunc(ctx context.Context, httpClient HTTPClient, param *requestParam
 }
 
 func mustDoRequest(ctx context.Context, httpClient HTTPClient, param *requestParameter) ([]byte, error) {
-	req, err := newHTTPRequest(ctx, param)
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to create http.Request: %w", err)
+	retry := retryer{
+		processFunc: processFunc(ctx, httpClient, param),
+		maxRetry:    getRetryCount(),
+	}
+	if err := retry.do(ctx); err != nil {
+		return []byte{}, err
 	}
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed http.Client do: %w", err)
-	}
-	defer resp.Body.Close()
-
-	b, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return []byte{}, fmt.Errorf("failed to read response body: %w", err)
+	if retry.statusCode >= 300 {
+		return retry.body, fmt.Errorf("failed to call API: %s", string(retry.body))
 	}
 
-	if resp.StatusCode >= 300 {
-		return b, fmt.Errorf("failed to call API: %s", string(b))
-	}
-
-	return b, nil
+	return retry.body, nil
 }
 
 func doRequestAndParseResponse(ctx context.Context, httpClient HTTPClient, param *requestParameter) (*Result, error) {

--- a/graph.go
+++ b/graph.go
@@ -782,7 +782,7 @@ func (g *Graph) Subtract(input *GraphSubtractInput) (*Result, error) {
 func (g *Graph) SubtractWithContext(ctx context.Context, input *GraphSubtractInput) (*Result, error) {
 	param, err := g.createSubtractRequestParameter(input)
 	if err != nil {
-		return &Result{}, fmt.Errorf("failed to create graph add parameter: %w", err)
+		return &Result{}, fmt.Errorf("failed to create graph subtract parameter: %w", err)
 	}
 
 	return doRequestAndParseResponse(ctx, g.httpClient, param)

--- a/graph.go
+++ b/graph.go
@@ -269,11 +269,11 @@ func (g *Graph) GetSVGWithContext(ctx context.Context, input *GraphGetSVGInput) 
 type GraphGetSVGInput struct {
 	// ID is a required field
 	ID          *string `json:"-"`
-	Date        *string `json:"date,omitempty"`
-	Mode        *string `json:"mode,omitempty"`
-	Appearance  *string `json:"appearance,omitempty"`
-	LessThan    *string `json:"lessThan,omitempty"`
-	GreaterThan *string `json:"greaterThan,omitempty"`
+	Date        *string `json:"-"`
+	Mode        *string `json:"-"`
+	Appearance  *string `json:"-"`
+	LessThan    *string `json:"-"`
+	GreaterThan *string `json:"-"`
 }
 
 func (g *Graph) createGetSVGRequestParameter(input *GraphGetSVGInput) *requestParameter {


### PR DESCRIPTION
## Summary

- `fix(graph): correct error message in SubtractWithContext` — copy-paste bug: error message said "add" instead of "subtract"
- `fix(api): add retry support to mustDoRequest` — `GetSVG` was the only method that did not respect `RetryCount`; aligned with `doRequest` / `doRequestAndParseResponse` by using the `retryer`
- `fix(graph): remove misleading json tags from GraphGetSVGInput` — fields on this struct are read manually as query parameters, never marshaled to JSON; replaced `json:"..."` tags with `json:"-"`

## Test plan

- [x] `make test` passes