### PR TITLE
fix: add json:"-" tags to non-marshaled input struct fields

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -447,7 +447,7 @@ func (g *Graph) StatsWithContext(ctx context.Context, input *GraphStatsInput) (*
 // GraphStatsInput is input of Graph.Stats().
 type GraphStatsInput struct {
 	// ID is a required field
-	ID *string
+	ID *string `json:"-"`
 }
 
 func (g *Graph) createStatsRequestParameter(input *GraphStatsInput) *requestParameter {
@@ -587,10 +587,10 @@ func (g *Graph) GetPixelDatesWithContext(ctx context.Context, input *GraphGetPix
 // GraphGetPixelDatesInput is input of Graph.GetPixelDates().
 type GraphGetPixelDatesInput struct {
 	// ID is a required field
-	ID       *string
-	From     *string
-	To       *string
-	WithBody *bool
+	ID       *string `json:"-"`
+	From     *string `json:"-"`
+	To       *string `json:"-"`
+	WithBody *bool   `json:"-"`
 }
 
 // Pixels is Date list of Pixel registered in the graph.
@@ -684,7 +684,7 @@ func (g *Graph) StopwatchWithContext(ctx context.Context, input *GraphStopwatchI
 // GraphStopwatchInput is input of Graph.Stopwatch().
 type GraphStopwatchInput struct {
 	// ID is a required field
-	ID *string
+	ID *string `json:"-"`
 }
 
 func (g *Graph) createStopwatchRequestParameter(input *GraphStopwatchInput) *requestParameter {

--- a/pixel.go
+++ b/pixel.go
@@ -71,7 +71,7 @@ func (p *Pixel) IncrementWithContext(ctx context.Context, input *PixelIncrementI
 // PixelIncrementInput is input of Pixel.Increment().
 type PixelIncrementInput struct {
 	// GraphID is a required field
-	GraphID *string
+	GraphID *string `json:"-"`
 }
 
 func (p *Pixel) createIncrementRequestParameter(input *PixelIncrementInput) *requestParameter {
@@ -99,7 +99,7 @@ func (p *Pixel) DecrementWithContext(ctx context.Context, input *PixelDecrementI
 // PixelDecrementInput is input of Pixel.Decrement().
 type PixelDecrementInput struct {
 	// GraphID is a required field
-	GraphID *string
+	GraphID *string `json:"-"`
 }
 
 func (p *Pixel) createDecrementRequestParameter(input *PixelDecrementInput) *requestParameter {
@@ -137,9 +137,9 @@ func (p *Pixel) GetWithContext(ctx context.Context, input *PixelGetInput) (*Quan
 // PixelGetInput is input of Pixel.Get().
 type PixelGetInput struct {
 	// GraphID is a required field
-	GraphID *string
+	GraphID *string `json:"-"`
 	// Date is required field.
-	Date *string
+	Date *string `json:"-"`
 }
 
 func (p *Pixel) createGetRequestParameter(input *PixelGetInput) *requestParameter {
@@ -296,9 +296,9 @@ func (p *Pixel) DeleteWithContext(ctx context.Context, input *PixelDeleteInput) 
 // PixelDeleteInput is input of Pixel.Delete().
 type PixelDeleteInput struct {
 	// GraphID is a required field
-	GraphID *string
+	GraphID *string `json:"-"`
 	// Date is a required field
-	Date *string
+	Date *string `json:"-"`
 }
 
 func (p *Pixel) createDeleteRequestParameter(input *PixelDeleteInput) *requestParameter {


### PR DESCRIPTION
## Summary

URL-path and query-parameter fields in several Input structs were missing `json:"-"` tags. These structs are never marshaled to JSON, so there is no functional impact, but the inconsistency contradicts the project convention documented in AGENTS.md ("Use `json:"-"` for fields that belong in the URL path").

Affected structs:

**graph.go**
- `GraphStatsInput.ID`
- `GraphGetPixelDatesInput.ID`, `From`, `To`, `WithBody`
- `GraphStopwatchInput.ID`

**pixel.go**
- `PixelIncrementInput.GraphID`
- `PixelDecrementInput.GraphID`
- `PixelGetInput.GraphID`, `Date`
- `PixelDeleteInput.GraphID`, `Date`

## Test plan

- [x] `make test` passes